### PR TITLE
http-conduit : Document usage of mkManagerSettings/TLSSettingsSimple.

### DIFF
--- a/http-conduit/Network/HTTP/Conduit.hs
+++ b/http-conduit/Network/HTTP/Conduit.hs
@@ -107,6 +107,22 @@
 -- >      let request = request' { checkStatus = \_ _ -> Nothing }
 -- >      res <- withManager $ httpLbs request
 -- >      print res
+--
+-- By default, when connecting to websites using HTTPS, functions in this
+-- package will throw an exception if the TLS certificate doesn't validate. To
+-- continue the HTTPS transaction even if the TLS cerficate validation fails,
+-- you should use 'mkManagerSetttings' as follows:
+--
+-- > import Network.Connection (TLSSettings (..))
+-- > import Network.HTTP.Conduit
+-- >
+-- > main :: IO ()
+-- > main = do
+-- >     request <- parseUrl "https://github.com/"
+-- >     let settings = mkManagerSettings (TLSSettingsSimple True False False) Nothing
+-- >     res <- withManagerSettings settings $ httpLbs request
+-- >     print res
+
 module Network.HTTP.Conduit
     ( -- * Perform a request
       simpleHttp


### PR DESCRIPTION
Add an explanation of how to use http-conduit to access a HTTPS
server with an TLS certificate that fails to validate.
