### PR TITLE
Link to http-client-multipart from http-conduit

### DIFF
--- a/http-conduit/http-conduit.cabal
+++ b/http-conduit/http-conduit.cabal
@@ -9,6 +9,8 @@ description:
     This package uses conduit for parsing the actual contents of the HTTP connection. It also provides higher-level functions which allow you to avoid directly dealing with streaming data. See <http://www.yesodweb.com/book/http-conduit> for more information.
     .
     The @Network.HTTP.Conduit.Browser@ module has been moved to <http://hackage.haskell.org/package/http-conduit-browser/>
+    .
+    The @Network.HTTP.Conduit.MultipartFormData@ module has been moved to <http://hackage.haskell.org/package/http-client-multipart/>
 category:        Web, Conduit
 stability:       Stable
 cabal-version:   >= 1.8


### PR DESCRIPTION
MultipartFormData module has moved without explanation, fix that.
