### PR TITLE
Bump lower bound on resourcet

### DIFF
--- a/http-client-conduit/http-client-conduit.cabal
+++ b/http-client-conduit/http-client-conduit.cabal
@@ -16,7 +16,7 @@ library
   build-depends:       base >= 4 && < 5
                      , http-client >= 0.2
                      , conduit
-                     , resourcet
+                     , resourcet >= 0.4.6
                      , bytestring
                      , transformers
   default-language:    Haskell2010


### PR DESCRIPTION
I tried installing the new `http-client` on my server. Compilation failed because `getInternalState` was not found when compiling `http-client-conduit`. Fixed by using `--constraint='resourcet>=4.6'`, but it might be a good idea to add this version bound so other people don't run into the same problem.
