### PR TITLE
clear Content-Type header on 302/303 redirect

### DIFF
--- a/http-client/Network/HTTP/Client/Response.hs
+++ b/http-client/Network/HTTP/Client/Response.hs
@@ -66,6 +66,7 @@ getRedirectedRequest req hs cookie_jar code
                     { method = "GET"
                     , requestBody = RequestBodyBS ""
                     , cookieJar = cookie_jar'
+                    , requestHeaders = filter ((/= hContentType) . fst) $ requestHeaders req'
                     }
                 else req' {cookieJar = cookie_jar'}
     | otherwise = Nothing


### PR DESCRIPTION
Prior to this change, when doing a POST multipart request that returns a
redirect, the redirected request still had the multipart/form-data content 
type, even though it's a GET request. Now, we just don't set a Content-Type
when following a redirect with a GET request.

I'm currently trying to interface with a site that returns a 500 Internal Server Error when
the GET request has a multipart content type. Chrome also clears the Content-Type header.

Maybe there are also other headers which should be cleared?
