### PR TITLE
SSL certificate rejected trying to access via proxy

### DIFF
--- a/http-client-tls/Network/HTTP/Client/TLS.hs
+++ b/http-client-tls/Network/HTTP/Client/TLS.hs
@@ -79,10 +79,10 @@ getTlsConnection tls sock = do
 getTlsProxyConnection
     :: NC.TLSSettings
     -> Maybe NC.SockSettings
-    -> IO (S.ByteString -> (Connection -> IO ()) -> Maybe HostAddress -> String -> Int -> IO Connection)
+    -> IO (S.ByteString -> (Connection -> IO ()) -> String -> Maybe HostAddress -> String -> Int -> IO Connection)
 getTlsProxyConnection tls sock = do
     context <- NC.initConnectionContext
-    return $ \connstr checkConn _ha host port -> do
+    return $ \connstr checkConn serverName _ha host port -> do
         --error $ show (connstr, host, port)
         conn <- NC.connectTo context NC.ConnectionParams
             { NC.connectionHostname = host
@@ -96,7 +96,7 @@ getTlsProxyConnection tls sock = do
 
         checkConn conn'
 
-        NC.connectionSetSecure context conn tls
+        NC.connectionSetSecure context (conn { NC.connectionID = (serverName, fromIntegral port) }) tls
 
         return conn'
 

--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -55,7 +55,7 @@ defaultManagerSettings = ManagerSettings
     { managerConnCount = 10
     , managerRawConnection = return openSocketConnection
     , managerTlsConnection = return $ \_ _ _ -> throwIO TlsNotSupported
-    , managerTlsProxyConnection = return $ \_ _ _ _ _ -> throwIO TlsNotSupported
+    , managerTlsProxyConnection = return $ \_ _ _ _ _ _ -> throwIO TlsNotSupported
     , managerResponseTimeout = Just 30000000
     , managerRetryableException = \e ->
         case fromException e of
@@ -361,4 +361,4 @@ getConn req m
                         sh@(StatusHeaders status _ _) <- parseStatusHeaders conn
                         unless (status == status200) $
                             throwIO $ ProxyConnectException ultHost ultPort $ Left $ S8.pack $ show sh
-                 in mTlsProxyConnection m connstr parse
+                 in mTlsProxyConnection m connstr parse (S8.unpack ultHost)

--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -458,7 +458,7 @@ data ManagerSettings = ManagerSettings
       -- ^ Create a TLS connection. Default behavior: throw an exception that TLS is not supported.
       --
       -- Since 0.1.0
-    , managerTlsProxyConnection :: IO (S.ByteString -> (Connection -> IO ()) -> Maybe NS.HostAddress -> String -> Int -> IO Connection)
+    , managerTlsProxyConnection :: IO (S.ByteString -> (Connection -> IO ()) -> String -> Maybe NS.HostAddress -> String -> Int -> IO Connection)
       -- ^ Create a TLS proxy connection. Default behavior: throw an exception that TLS is not supported.
       --
       -- Since 0.2.2
@@ -500,7 +500,7 @@ data Manager = Manager
     -- ^ Copied from 'managerResponseTimeout'
     , mRawConnection :: Maybe NS.HostAddress -> String -> Int -> IO Connection
     , mTlsConnection :: Maybe NS.HostAddress -> String -> Int -> IO Connection
-    , mTlsProxyConnection :: S.ByteString -> (Connection -> IO ()) -> Maybe NS.HostAddress -> String -> Int -> IO Connection
+    , mTlsProxyConnection :: S.ByteString -> (Connection -> IO ()) -> String -> Maybe NS.HostAddress -> String -> Int -> IO Connection
     , mRetryableException :: SomeException -> Bool
     , mWrapIOException :: forall a. IO a -> IO a
     }


### PR DESCRIPTION
When connecting to an HTTPS server via a proxy, the server's certificate is rejected unexpectedly with the NameMismatch exception.

Code:

``` .haskell
req <- parseUrl "https://secure.example.com"
let req' = req { proxy = Just $ Proxy "proxy.example.com" 8080 }
withManager $ httpLbs req'
```

and got:

```
*** Exception: TlsException (HandshakeFailed (Error_Protocol ("certificate rejected: [NameMismatch \"proxy.example.com\"]",True,CertificateUnknown)))
```

It seems that the http-client-tls package uses the proxy hostname as the SSL ServerName in the verification process of the SSL certificate.

This PR fixes this problem, and I've tested this code with squid-2.7.STABLE9-4.1+b1 (debian wheezy).
