### PR TITLE
http-client: Expose the "Response" constructor.

### DIFF
--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -114,7 +114,7 @@ module Network.HTTP.Client
     , NeedsPopper
     , GivesPopper
       -- * Response
-    , Response
+    , Response(..)
     , responseStatus
     , responseVersion
     , responseHeaders


### PR DESCRIPTION
Use-case: I want to catch exceptional responses in place and substitute them for dummy values.
