### PR TITLE
Part Headers

### DIFF
--- a/http-client/Network/HTTP/Client/MultipartFormData.hs
+++ b/http-client/Network/HTTP/Client/MultipartFormData.hs
@@ -96,9 +96,9 @@ instance Show Part where
             . showString " "
             . showsPrec 11 c
             . showString " "
-            . showString "<m (RequestBody m)>"
-            . showString " "
             . showsPrec 11 h
+            . showString " "
+            . showString "<m (RequestBody m)>"
 
 -- | Make a 'Part' whose content is a strict 'BS.ByteString'.
 --


### PR DESCRIPTION
Resolves #76 
- Do not export `Part` constructor
- Export `Part` member accessors instead
- Add `addPartHeaders` to add headers
- Update `renderPart` to add additional headers

It seems like this has the potential to break a few downstream libraries, but the four libraries in this repo seem to build at least.

A few questions:
- Should I remove `addPartHeaders`, since exporting the `partHeaders` accessor seems to allow adding headers directly via record update.
- Is it necessary to encode the header content in any way? I don't see this being done in the `Content-Disposition` header, but I was wondering anyway.

Thanks.
