### PR TITLE
Relaxes handling of Location headers

### DIFF
--- a/http-client/Network/HTTP/Client/Response.hs
+++ b/http-client/Network/HTTP/Client/Response.hs
@@ -18,7 +18,7 @@ import qualified Data.ByteString.Lazy as L
 import Data.Default.Class (def)
 
 import qualified Network.HTTP.Types as W
-import Network.URI (parseURIReference)
+import Network.URI (parseURIReference, escapeURIString, isAllowedInURI)
 
 import Network.HTTP.Client.Types
 
@@ -56,7 +56,8 @@ getRedirectedRequest :: Request -> W.ResponseHeaders -> CookieJar -> Int -> Mayb
 getRedirectedRequest req hs cookie_jar code
     | 300 <= code && code < 400 = do
         l' <- lookup "location" hs
-        req' <- setUriRelative req =<< parseURIReference (S8.unpack l')
+        let l = escapeURIString isAllowedInURI (S8.unpack l')
+        req' <- setUriRelative req =<< parseURIReference l
         return $
             if code == 302 || code == 303
                 -- According to the spec, this should *only* be for status code


### PR DESCRIPTION
Some web servers send Location headers, whose values are not valid
URLs (e.g. containing spaces). These are now accepted. The invalid
characters are escaped the same way as parseUrl does.

Fixes #83
