### PR TITLE
Fix lax parsing #94

### DIFF
--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -493,8 +493,9 @@ envHelper name eh = do
         Just str -> do
             let invalid = throwIO $ InvalidProxyEnvironmentVariable name (T.pack str)
             p <- maybe invalid return $ do
-                uri <- U.parseURI str
-                uri <- if U.uriScheme uri == "http:" then return uri else U.parseURI $ "http://" ++ str
+                uri <- case U.parseURI str of
+                    Just u | U.uriScheme u == "http:" -> return u
+                    _ -> U.parseURI $ "http://" ++ str
 
                 guard $ U.uriScheme uri == "http:"
                 guard $ null (U.uriPath uri) || U.uriPath uri == "/"

--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -494,7 +494,7 @@ envHelper name eh = do
             let invalid = throwIO $ InvalidProxyEnvironmentVariable name (T.pack str)
             p <- maybe invalid return $ do
                 uri <- U.parseURI str
-                       `mplus` U.parseURI ("http://" ++ str)
+                uri <- if U.uriScheme uri == "http:" then return uri else U.parseURI $ "http://" ++ str
 
                 guard $ U.uriScheme uri == "http:"
                 guard $ null (U.uriPath uri) || U.uriPath uri == "/"


### PR DESCRIPTION
The variable `localhost:40` gets parsed by the network URI stuff as a URI scheme `localhost`, so it does pass the parsing, so never gets to the `mplus` guard. I've tested this code and it seems to work in all the cases.