### PR TITLE
http-client exposes module Network.HTTP.Client.Types

### DIFF
--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -18,6 +18,7 @@ flag network-uri
 
 library
   exposed-modules:     Network.HTTP.Client
+                       Network.HTTP.Client.Types
                        Network.HTTP.Client.MultipartFormData
                        Network.HTTP.Client.Internal
   other-modules:       Network.HTTP.Client.Body
@@ -28,7 +29,6 @@ library
                        Network.HTTP.Client.Manager
                        Network.HTTP.Client.Request
                        Network.HTTP.Client.Response
-                       Network.HTTP.Client.Types
                        Network.HTTP.Client.Util
   build-depends:       base              >= 4.5    && < 5
                      , bytestring        >= 0.9


### PR DESCRIPTION
Dear Michael,
This pull request permits access to the CJ constructor and the `expose` selector on `CJ` so that one can pick cookies in the cookieJar. In my case, in a redirect history, I am having one cookie with https off and another with http on, so I'd like to drop one for now..