### PR TITLE
Allow HTTPS proxies

### DIFF
--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -494,10 +494,13 @@ envHelper name eh = do
             let invalid = throwIO $ InvalidProxyEnvironmentVariable name (T.pack str)
             p <- maybe invalid return $ do
                 uri <- case U.parseURI str of
-                    Just u | U.uriScheme u == "http:" -> return u
+                    Just u | U.uriScheme u == "http:"  -> return u
+                           | U.uriScheme u == "https:" -> return u
                     _ -> U.parseURI $ "http://" ++ str
 
-                guard $ U.uriScheme uri == "http:"
+                guard $
+                  (U.uriScheme uri == "http:" || U.uriScheme uri == "https:")
+
                 guard $ null (U.uriPath uri) || U.uriPath uri == "/"
                 guard $ null $ U.uriQuery uri
                 guard $ null $ U.uriFragment uri

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -97,6 +97,7 @@ test-suite spec-nonet
   build-depends:       base
                      , http-client
                      , hspec
+                     , base-compat
                      , monad-control
                      , bytestring
                      , text


### PR DESCRIPTION
This commit fixes a bug where specifying a proxy prefixed by 'https' caused an HttpException to be raised. This seems like a scheme that should be valid, particularly since we're allowing an `https_proxy` to be specified in the environment.

With this change I also added test cases for previous behavior that wasn't tested, i.e., 'http:' should be a valid proxy uri scheme name, and 'ftp:' should not be a valid proxy uri scheme name.