### PR TITLE
Provide a sane cross-platform way to check server certificates with openssl

### DIFF
--- a/http-client-openssl/Network/HTTP/Client/OpenSSL.hs
+++ b/http-client-openssl/Network/HTTP/Client/OpenSSL.hs
@@ -1,7 +1,8 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 -- | Support for making connections via the OpenSSL library.
 module Network.HTTP.Client.OpenSSL
-    ( opensslManagerSettings
+    ( defaultOpensslManagerSettings
+    , opensslManagerSettings
     , defaultMakeContext
     , withOpenSSL
     ) where
@@ -14,6 +15,11 @@ import OpenSSL
 import qualified Network.Socket as N
 import qualified OpenSSL.Session       as SSL
 import OpenSSL.X509.SystemStore (contextLoadSystemCerts)
+
+-- | A sane default value for 'ManagerSettings' that enables server
+-- certificate verification.
+defaultOpensslManagerSettings :: ManagerSettings
+defaultOpensslManagerSettings = opensslManagerSettings defaultMakeContext
 
 -- | Note that it is the caller's responsibility to pass in an appropriate
 -- context.

--- a/http-client-openssl/http-client-openssl.cabal
+++ b/http-client-openssl/http-client-openssl.cabal
@@ -19,6 +19,7 @@ library
                      , http-client >= 0.2
                      , network
                      , HsOpenSSL
+                     , HsOpenSSL-x509-system
   default-language:    Haskell2010
 
 test-suite spec


### PR DESCRIPTION
Currently `http-client-openssl` puts the burden of selecting the right trust roots to its users. If one wants to write an cross-platform client that verifies server certificates, there is no easy solution. On the other hand, `http-client-tls` does verify server certificates against the system's trust roots. This functionality is automatically offered by the `tls` package via the `x509-system` package. I wrote a new package [1],[2] that performs the same task for `HsOpenSSL`, using the same strategy as `x509-system`.

This pull request provides an easy cross-platform way to enable server certificate verification for `http-client-openssl` using `HsOpenSSL-x509-system`.

See also #2.

[1] https://hackage.haskell.org/package/HsOpenSSL-x509-system
[2] https://github.com/redneb/HsOpenSSL-x509-system
