### PR TITLE
Gate manager creation with a withSocketsDo for Windows user conveninece.

### DIFF
--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -171,6 +171,7 @@ addToList now maxCount x l@(Cons _ currCount _ _)
 -- Since 0.1.0
 newManager :: ManagerSettings -> IO Manager
 newManager ms = do
+    NS.withSocketsDo $ return ()
     rawConnection <- managerRawConnection ms
     tlsConnection <- managerTlsConnection ms
     tlsProxyConnection <- managerTlsProxyConnection ms


### PR DESCRIPTION
Here is an example I have tested on my Windows machine.

```haskell
-- example.hs
{-# LANGUAGE OverloadedStrings #-}
import Network.HTTP.Client

main = do
  withManager defaultManagerSettings $ \m -> do
    print =<< httpNoBody "http://google.com" m
```

When compiled against http-client-0.4.8 from hackage:

```
example.hs: FailedConnectionException2 "google.com" 80 False getAddrInfo: does n
ot exist (error 10093)
```

When compiled against this fork of http-client, it correctly retrieves and prints the Response.

Both times it was compiled against `network-2.4.2.3`, as included in the latest Haskell Platform.

(Tangent: both times, it spit out a bunch of warning messages about "X from blah32 is linked instead of __imp_X". These warnings do not cause it to crash, and do not prevent this sample use case from working correctly as far as I can tell.)