### PR TITLE
Expect: 100-continue

### DIFF
--- a/http-client/Network/HTTP/Client/Core.hs
+++ b/http-client/Network/HTTP/Client/Core.hs
@@ -89,9 +89,9 @@ httpRaw req0 m = do
     -- connections after accepting the request headers, so we need to check for
     -- exceptions in both.
     ex <- try $ do
-        requestBuilder req ci
+        cont <- requestBuilder req ci
 
-        getResponse connRelease timeout' req ci
+        getResponse connRelease timeout' req ci cont
 
     case (ex, isManaged) of
         -- Connection was reused, and might have been closed. Try again

--- a/http-client/Network/HTTP/Client/Headers.hs
+++ b/http-client/Network/HTTP/Client/Headers.hs
@@ -39,8 +39,8 @@ parseStatusHeaders conn timeout' cont
         next = nextStatusHeaders >>= maybe next return
 
     getStatusContinue sendBody = do
-        sh <- withTimeout nextStatusHeaders
-        case sh of
+        status <- withTimeout nextStatusHeaders
+        case status of
             Just  s -> return s
             Nothing -> sendBody >> getStatusNoContinue
 

--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -420,7 +420,7 @@ getConn req m
                         , " HTTP/1.1\r\n\r\n"
                         ]
                     parse conn = do
-                        sh@(StatusHeaders status _ _) <- parseStatusHeaders conn
+                        sh@(StatusHeaders status _ _) <- parseStatusHeaders conn Nothing Nothing
                         unless (status == status200) $
                             throwIO $ ProxyConnectException ultHost ultPort $ Left $ S8.pack $ show sh
                  in mTlsProxyConnection m connstr parse (S8.unpack ultHost)

--- a/http-client/test-nonet/Network/HTTP/Client/HeadersSpec.hs
+++ b/http-client/test-nonet/Network/HTTP/Client/HeadersSpec.hs
@@ -20,7 +20,7 @@ spec = describe "HeadersSpec" $ do
                 , "\nignored"
                 ]
         (connection, _, _) <- dummyConnection input
-        statusHeaders <- parseStatusHeaders connection
+        statusHeaders <- parseStatusHeaders connection Nothing Nothing
         statusHeaders `shouldBe` StatusHeaders status200 (HttpVersion 1 1)
             [ ("foo", "bar")
             , ("baz", "bin")

--- a/http-client/test-nonet/Network/HTTP/Client/HeadersSpec.hs
+++ b/http-client/test-nonet/Network/HTTP/Client/HeadersSpec.hs
@@ -25,3 +25,38 @@ spec = describe "HeadersSpec" $ do
             [ ("foo", "bar")
             , ("baz", "bin")
             ]
+
+    it "Expect: 100-continue (success)" $ do
+        let input =
+                [ "HTTP/1.1 100 Continue\r\n\r\n"
+                , "HTTP/1.1 200 OK\r\n"
+                , "foo: bar\r\n\r\n"
+                ]
+        (conn, out, _) <- dummyConnection input
+        let sendBody = connectionWrite conn "data"
+        statusHeaders <- parseStatusHeaders conn Nothing (Just sendBody)
+        statusHeaders `shouldBe` StatusHeaders status200 (HttpVersion 1 1) [ ("foo", "bar") ]
+        out >>= (`shouldBe` ["data"])
+
+    it "Expect: 100-continue (failure)" $ do
+        let input =
+                [ "HTTP/1.1 417 Expectation Failed\r\n\r\n"
+                ]
+        (conn, out, _) <- dummyConnection input
+        let sendBody = connectionWrite conn "data"
+        statusHeaders <- parseStatusHeaders conn Nothing (Just sendBody)
+        statusHeaders `shouldBe` StatusHeaders status417 (HttpVersion 1 1) []
+        out >>= (`shouldBe` [])
+
+    it "100 Continue without expectation is OK" $ do
+        let input =
+                [ "HTTP/1.1 100 Continue\r\n\r\n"
+                , "HTTP/1.1 200 OK\r\n"
+                , "foo: bar\r\n\r\n"
+                , "result"
+                ]
+        (conn, out, inp) <- dummyConnection input
+        statusHeaders <- parseStatusHeaders conn Nothing Nothing
+        statusHeaders `shouldBe` StatusHeaders status200 (HttpVersion 1 1) [ ("foo", "bar") ]
+        out >>= (`shouldBe` [])
+        inp >>= (`shouldBe` ["result"])

--- a/http-client/test-nonet/Network/HTTP/Client/RequestSpec.hs
+++ b/http-client/test-nonet/Network/HTTP/Client/RequestSpec.hs
@@ -1,28 +1,85 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Network.HTTP.Client.RequestSpec where
 
+import Blaze.ByteString.Builder (fromByteString)
 import Control.Applicative ((<$>))
-import Control.Monad (join)
-import Data.Maybe (isJust)
-import Test.Hspec
+import Control.Monad (join, forM_)
+import Data.IORef
+import Data.Maybe (isJust, fromMaybe)
 import Network.HTTP.Client (parseUrl, requestHeaders, applyBasicProxyAuth)
-import Control.Monad (forM_)
+import Network.HTTP.Client.Internal
+import Test.Hspec
 
 spec :: Spec
 spec = do
-  describe "case insensitive scheme" $ do
-    forM_ ["http://example.com", "httP://example.com", "HttP://example.com", "HttPs://example.com"] $ \url ->
-      it url $ case parseUrl url of
-        Nothing -> error "failed"
-        Just _ -> return () :: IO ()
-    forM_ ["ftp://example.com"] $ \url ->
-      it url $ case parseUrl url of
-        Nothing -> return () :: IO ()
-        Just req -> error $ show req
-  describe "applyBasicProxyAuth" $ do
-    let request = applyBasicProxyAuth "user" "pass" <$> parseUrl "http://example.org"
-        field   = join $ lookup "Proxy-Authorization" . requestHeaders <$> request
-    it "Should add a proxy-authorization header" $ do
-      field `shouldSatisfy` isJust
-    it "Should add a proxy-authorization header with the specified username and password." $ do
-      field `shouldBe` Just "Basic dXNlcjpwYXNz"
+    describe "case insensitive scheme" $ do
+        forM_ ["http://example.com", "httP://example.com", "HttP://example.com", "HttPs://example.com"] $ \url ->
+            it url $ case parseUrl url of
+                Nothing -> error "failed"
+                Just _ -> return () :: IO ()
+        forM_ ["ftp://example.com"] $ \url ->
+            it url $ case parseUrl url of
+                Nothing -> return () :: IO ()
+                Just req -> error $ show req
+
+    describe "applyBasicProxyAuth" $ do
+        let request = applyBasicProxyAuth "user" "pass" <$> parseUrl "http://example.org"
+            field   = join $ lookup "Proxy-Authorization" . requestHeaders <$> request
+        it "Should add a proxy-authorization header" $ do
+            field `shouldSatisfy` isJust
+        it "Should add a proxy-authorization header with the specified username and password." $ do
+            field `shouldBe` Just "Basic dXNlcjpwYXNz"
+
+    describe "requestBuilder" $ do
+        it "sends the full request, combining headers and body in the non-streaming case" $ do
+            let Just req  = parseUrl "http://localhost"
+            let      req' = req { method = "PUT", path = "foo" }
+            (conn, out, _) <- dummyConnection []
+            forM_ (bodies `zip` out1) $ \(b, o) -> do
+                cont <- requestBuilder (req' { requestBody = b } ) conn
+                (const "<IO ()>" <$> cont) `shouldBe` Nothing
+                out >>= (`shouldBe` o)
+
+        it "sends only headers and returns an action for the body on 'Expect: 100-continue'" $ do
+            let Just req  = parseUrl "http://localhost"
+            let      req' = req { requestHeaders = [("Expect", "100-continue")]
+                                , method = "PUT"
+                                , path = "foo"
+                                }
+            (conn, out, _) <- dummyConnection []
+            forM_ (bodies `zip` out2) $ \(b, (h, o)) -> do
+                cont <- requestBuilder (req' { requestBody = b } ) conn
+                out >>= (`shouldBe` [h, ""])
+                fromMaybe (return ()) cont
+                out >>= (`shouldBe` o)
+      where
+        bodies = [ RequestBodyBS "data"
+                 , RequestBodyLBS "data"
+                 , RequestBodyBuilder 4 (fromByteString "data")
+                 , RequestBodyStream 4 (popper ["data"] >>=)
+                 , RequestBodyStreamChunked (popper ["data"] >>=)
+                 ]
+
+        out1 = [ [nonChunked <> "\r\ndata"]
+               , [nonChunked <> "\r\ndata"]
+               , [nonChunked <> "\r\ndata"]
+               , [nonChunked <> "\r\n", "", "data"]
+               , [chunked <> "\r\n", "", "4\r\n","data","\r\n","0\r\n\r\n"]
+               ]
+
+        out2 = [ (nonChunked <> "Expect: 100-continue\r\n\r\n", ["data"])
+               , (nonChunked <> "Expect: 100-continue\r\n\r\n", ["data"])
+               , (nonChunked <> "Expect: 100-continue\r\n\r\n", ["data"])
+               , (nonChunked <> "Expect: 100-continue\r\n\r\n", ["data"])
+               , (chunked    <> "Expect: 100-continue\r\n\r\n", ["4\r\n","data","\r\n","0\r\n\r\n"])
+               ]
+
+        nonChunked = "PUT /foo HTTP/1.1\r\nHost: localhost\r\nAccept-Encoding: gzip\r\nContent-Length: 4\r\n"
+        chunked    = "PUT /foo HTTP/1.1\r\nHost: localhost\r\nAccept-Encoding: gzip\r\nTransfer-Encoding: chunked\r\n"
+
+        popper dat = do
+            r <- newIORef dat
+            return . atomicModifyIORef' r $ \xs ->
+                case xs of
+                    (x:xs') -> (xs', x)
+                    [] -> ([], "")

--- a/http-client/test-nonet/Network/HTTP/Client/ResponseSpec.hs
+++ b/http-client/test-nonet/Network/HTTP/Client/ResponseSpec.hs
@@ -16,7 +16,7 @@ main = hspec spec
 
 spec :: Spec
 spec = describe "ResponseSpec" $ do
-    let getResponse' conn = getResponse (const $ return ()) Nothing req conn
+    let getResponse' conn = getResponse (const $ return ()) Nothing req conn Nothing
         Just req = parseUrl "http://localhost"
     it "basic" $ do
         (conn, _, _) <- dummyConnection


### PR DESCRIPTION
This PR proposes an implementation for the HTTP 1.1 `Expect: 100-continue` / `100 Continue` interaction whereby the client only sends the request body once it has received the `100 Continue`. The behaviour (including timeout behaviour) when `Expect: 100-continue` is **not** set should be identical to the way it is now. If the header is set, two timeouts apply, the first for waiting on the `100 Continue` and the second for waiting on the final response.

### Context / Motivation

For completeness, the specific situation where I ran into the need for this feature is a service that streams uploads from clients directly to S3. S3 closes idle connections quite aggressively after ~5 seconds. When these connections (in state `CLOSE_WAIT`) then end up being used for another upload before being closed by the `Manager`, part or all of the request body is pushed into the "dead" socket (buffer) and thus lost due to the source not being repeatable. That the connection is closed is usually not immediately discovered during sending, depending on how much data is being sent, but eventually fails quickly on receiving with `NoResponseDataReceived`. The subsequent retry on a new connection is then doomed to time out due to part of the data being gone already.
By expecting a `100 Continue`, the closed connection is guaranteed to be detected before the body is being sent. In the context of S3 it is also a good mechanism to handle [potential redirects](http://docs.aws.amazon.com/AmazonS3/latest/dev/RESTRedirect.html) without sending (parts of) the body twice. For these reasons, it seems to be a good idea to use `Expect: 100-continue` for streaming S3 uploads from non-repeatable sources.