### PR TITLE
Allows the presence of 'content-length' header for chunked transfers.

### DIFF
--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.4.11
+
+* Ignore the 'Content-Length' header if the body contains chunked data [#115](https://github.com/snoyberg/http-client/pull/115)
+
 ## 0.4.10
 
 * Expect: 100-continue [#114](https://github.com/snoyberg/http-client/pull/114)

--- a/http-client/Network/HTTP/Client/Response.hs
+++ b/http-client/Network/HTTP/Client/Response.hs
@@ -98,13 +98,9 @@ getResponse connRelease timeout' req@(Request {..}) conn cont = do
         toPut = Just "close" /= lookup "connection" hs && version > W.HttpVersion 1 0
         cleanup bodyConsumed = connRelease $ if toPut && bodyConsumed then Reuse else DontReuse
 
-    when (isJust mcl && isChunked) $ do
-        cleanup False
-        throwIO ResponseLengthAndChunkingBothUsed
-
     body <-
         -- RFC 2616 section 4.4_1 defines responses that must not include a body
-        if hasNoBody method (W.statusCode s) || mcl == Just 0
+        if hasNoBody method (W.statusCode s) || (mcl == Just 0 && not isChunked)
             then do
                 cleanup True
                 return brEmpty

--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -115,12 +115,11 @@ data HttpException = StatusCodeException Status ResponseHeaders CookieJar
                    -- ^ Environment name and value
                    --
                    -- Since 0.4.7
-
                    | ResponseLengthAndChunkingBothUsed
                    -- ^ Detect a case where both the @content-length@ header
-                   -- and @transfer-encoding: chunked@ are used.
+                   -- and @transfer-encoding: chunked@ are used. Since 0.4.8.
                    --
-                   -- Since 0.4.8
+                   -- Since 0.4.11 this exception isn't thrown anymore.
     deriving (Show, T.Typeable)
 instance Exception HttpException
 

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -1,5 +1,5 @@
 name:                http-client
-version:             0.4.10
+version:             0.4.11
 synopsis:            An HTTP client engine, intended as a base layer for more user-friendly packages.
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client


### PR DESCRIPTION
After ed0b0b71f7bdd1a769a864bedd73c059cc1676e4 , the presence of both 'content-length' and 'transfer-encoding: chunked' rises an error. Although this is the ideal solution, there some real word, non-RFC 2616 servers out there that send chunkend bodies with 'content-length' headers.

This PR basically reverts ed0b0b71f7bdd1a769a864bedd73c059cc1676e4. The goal is to accept a chunked transfer even if the 'content-length' is present by ignoring its presence. In other words, the body acquisition should proceed as in any other chunked transfer.
