### PR TITLE
Fix getUri to insert "?" to uriQuery when necessary.

### DIFF
--- a/http-client/Network/HTTP/Client/Request.hs
+++ b/http-client/Network/HTTP/Client/Request.hs
@@ -107,7 +107,10 @@ getUri req = URI
         , uriPort = ':' : show (port req)
         }
     , uriPath = S8.unpack $ path req
-    , uriQuery = S8.unpack $ queryString req
+    , uriQuery =
+        case S8.uncons $ queryString req of
+            Just (c, _) | c /= '?' -> '?' : (S8.unpack $ queryString req)
+            _ -> S8.unpack $ queryString req
     , uriFragment = ""
     }
 


### PR DESCRIPTION
`requestBuilder` function allows `queryString` of a `Request` not to begin with "?" character, and it inserts "?" when necessary.

`getUri` should do the same thing. Otherwise `applyCheckStatus` in `Network.Client.Core` module can produce `StatusCodeException` with wrong URI in its "X-Request-URL" field in such a case. I encountered the problem with influxdb package.