### PR TITLE
Support no_proxy environment variable. #140

### DIFF
--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -37,6 +37,7 @@ import qualified Data.ByteString.Lazy as L
 
 import qualified Blaze.ByteString.Builder as Blaze
 
+import Data.Char (toLower)
 import Data.Text (Text)
 import qualified Data.Text as T
 import Data.Text.Read (decimal)
@@ -506,7 +507,8 @@ envHelper :: Text -> EnvHelper -> IO (Request -> Request)
 envHelper name eh = do
     env <- getEnvironment
     let lenv = Map.fromList $ map (first $ T.toLower . T.pack) env
-    case lookup (T.unpack name) env <|> Map.lookup name lenv of
+        lookupEnvVar n = lookup (T.unpack n) env <|> Map.lookup n lenv
+    case lookupEnvVar name of
         Nothing  -> return noEnvProxy
         Just ""  -> return noEnvProxy
         Just str -> do
@@ -541,9 +543,17 @@ envHelper name eh = do
 
                 Just $ (Proxy (S8.pack $ U.uriRegName auth) port, muserpass)
             return $ \req ->
-                maybe id (uncurry applyBasicProxyAuth) muserpass
-                req { proxy = Just p }
+                if host req `hasDomainSuffixIn` lookupEnvVar "no_proxy"
+                then noEnvProxy req
+                else maybe id (uncurry applyBasicProxyAuth) muserpass
+                     req { proxy = Just p }
     where noEnvProxy = case eh of
             EHFromRequest -> id
             EHNoProxy     -> \req -> req { proxy = Nothing }
             EHUseProxy p  -> \req -> req { proxy = Just p  }
+          prefixed s | S8.head s == '.' = s
+                     | otherwise = S8.cons '.' s
+          domainSuffixes no_proxy = [ prefixed $ S8.dropWhile (== ' ') suffix | suffix <- S8.split ',' (S8.pack (map toLower no_proxy)), not (S8.null suffix)]
+          hasDomainSuffixIn _    Nothing         = False
+          hasDomainSuffixIn _    (Just "")       = False
+          hasDomainSuffixIn host (Just no_proxy) = any (`S8.isSuffixOf` prefixed (S8.map toLower host)) (domainSuffixes no_proxy)


### PR DESCRIPTION
Sorry if I've done any dumb stuff here. I tried to find a spec, and the nearest I could find was [some ancient info from W3C](http://www.w3.org/Daemon/User/Proxies/ProxyClients.html). I've thus implemented a subset of what other popular libraries support.

`no_proxy` contains a list of domain suffixes, separated by commas. The domain suffixes may optionally have leading periods; the commas may optionally have trailing spaces.

For example, if `no_proxy=internal.company.com, .other.company.com`, requests to `internal.company.com`, `foo.internal.company.com`, and `other.company.com` will avoid the proxy. Requests to `notactuallyinternal.company.com` will still go via the proxy.

##### Differences to other implementations:

###### Domain suffix vs. string suffix
wget and Python's urllib3 avoid the proxy if one of the `no_proxy` hosts is a string suffix of the request host, rather than a domain suffix (with special casing so `no_proxy=.foo.example` avoids the proxy for requests to `foo.example`).

###### Ignoring case/spaces
Some implementations ignore all spaces, rather than just `0x20`s following a comma. Some implementations also use case-sensitive domain handling.

###### Port-specific rules
Ruby's stdlib implementation can be made to apply only to specific ports.

###### Avoiding the proxy for CADR ranges
Python's urllib3 allows you to specify e.g. `no_proxy=internal.company.com,192.168.0.0/16`.

###### Avoiding the proxy for all requests
Ruby and cURL avoid the proxy for all requests if `no_proxy=*` is set.

