### PR TITLE
Expose brReadSome in Network.HTTP.Client

### DIFF
--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -154,6 +154,7 @@ module Network.HTTP.Client
       -- ** Response body
     , BodyReader
     , brRead
+    , brReadSome
     , brConsume
       -- * Misc
     , HttpException (..)

--- a/http-client/Network/HTTP/Client/Body.hs
+++ b/http-client/Network/HTTP/Client/Body.hs
@@ -33,6 +33,10 @@ import qualified Data.Streaming.Zlib as Z
 brRead :: BodyReader -> IO S.ByteString
 brRead = id
 
+-- | Continuously call 'brRead', building up a lazy ByteString until a chunk is
+-- constructed that is at least as many bytes as requested.
+--
+-- Since 0.4.20
 brReadSome :: BodyReader -> Int -> IO L.ByteString
 brReadSome brRead =
     loop id


### PR DESCRIPTION
I'm building a streaming interface to http-client (quiver-http) and am finding that brRead is often returning one to five byte chunks.

Quiver is nowhere near as optimised as conduit or pipes and I need to send larger chunks to get any performance.

Copy/pasting brReadSome and using it to build reasonable sized chunks made my performance problems go away entirely; would you consider exposing it?