### PR TITLE
Feature request: Async streaming of request

### DIFF
--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -213,6 +213,8 @@ data RequestBody
     | RequestBodyBuilder Int64 Builder
     | RequestBodyStream Int64 (GivesPopper ())
     | RequestBodyStreamChunked (GivesPopper ())
+    | RequestBodyStreamAsync Int64 (GivesPopper ())
+    | RequestBodyStreamChunkedAsync (GivesPopper ())
     deriving T.Typeable
 -- |
 --


### PR DESCRIPTION
In trying to stream large amounts of data (hundreds of GB up, and down) over HTTP, I've hit an issue.

It appears that http-client only allows for the request to be streamed out, then the response streamed in, sequentially.

This is due to the continuation passing nature of the API, where you only get access to the response once the request has been fully sent.

My use case requires the output to be consumed as we go, as the server streams output before the request is fully consumed.

This PR is the approach I've personally taken to make this work, but I've ignored errors in the thread. I was wondering if you had input on alternative approaches, perhaps including modifying the API. If you are OK with this approach, then perhaps we can add exception handling and everything will be splendid.