### PR TITLE
Make sure we never read from or write to closed socket

### DIFF
--- a/http-client/Network/HTTP/Client/Connection.hs
+++ b/http-client/Network/HTTP/Client/Connection.hs
@@ -85,15 +85,39 @@ makeConnection :: IO ByteString -- ^ read
                -> IO Connection
 makeConnection r w c = do
     istack <- newIORef []
+
+    -- it is necessary to make sure we never read from or write to
+    -- already closed connection.
+    closedVar <- newIORef False
+
     _ <- mkWeakIORef istack c
     return $! Connection
-        { connectionRead = join $ atomicModifyIORef istack $ \stack ->
-            case stack of
-                x:xs -> (xs, return x)
-                [] -> ([], r)
-        , connectionUnread = \x -> atomicModifyIORef istack $ \stack -> (x:stack, ())
-        , connectionWrite = w
-        , connectionClose = c
+        { connectionRead = do
+            closed <- readIORef closedVar
+            when closed $
+              throwIO ConnectionClosed
+            join $ atomicModifyIORef istack $ \stack ->
+              case stack of
+                  x:xs -> (xs, return x)
+                  [] -> ([], r)
+
+        , connectionUnread = \x -> do
+            closed <- readIORef closedVar
+            when closed $
+              throwIO ConnectionClosed
+            atomicModifyIORef istack $ \stack -> (x:stack, ())
+
+        , connectionWrite = \x -> do
+            closed <- readIORef closedVar
+            when closed $
+              throwIO ConnectionClosed
+            w x
+
+        , connectionClose = do
+            closed <- readIORef closedVar
+            unless closed $
+              c
+            writeIORef closedVar True
         }
 
 socketConnection :: Socket -> Int -> IO Connection

--- a/http-client/Network/HTTP/Client/Core.hs
+++ b/http-client/Network/HTTP/Client/Core.hs
@@ -218,12 +218,10 @@ httpRedirect count0 http' req0 = go count0 req0 []
                 -- instead just close the connection.
                 let maxFlush = 1024
                 lbs <- brReadSome (responseBody res) maxFlush
-                    -- Ignore IO exceptions at this point. A server may
-                    -- terminate the connection immediately in some cases, such
-                    -- as when using withResponseHistory (where the response
-                    -- body may be flushed before getting this far). See:
+                    -- The connection may already be closed, e.g.
+                    -- when using withResponseHistory. See
                     -- https://github.com/snoyberg/http-client/issues/169
-                    `catch` \(_ :: IOException) -> return L.empty
+                    `catch` \(_ :: ConnectionClosed) -> return L.empty
                 responseClose res
 
                 -- And now perform the actual redirect

--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -7,6 +7,7 @@ module Network.HTTP.Client.Types
     ( BodyReader
     , Connection (..)
     , StatusHeaders (..)
+    , ConnectionClosed (..)
     , HttpException (..)
     , Cookie (..)
     , CookieJar (..)
@@ -75,11 +76,19 @@ data Connection = Connection
     , connectionWrite :: S.ByteString -> IO ()
       -- ^ Send data to server
     , connectionClose :: IO ()
+      -- ^ Close connection. Any successive operation on the connection
+      -- (exept closing) should fail with `ConnectionClosed` exception.
+      -- It is allowed to close connection multiple times.
     }
     deriving T.Typeable
 
 data StatusHeaders = StatusHeaders Status HttpVersion RequestHeaders
     deriving (Show, Eq, Ord, T.Typeable)
+
+data ConnectionClosed = ConnectionClosed
+  deriving (Eq, Show)
+
+instance Exception ConnectionClosed
 
 data HttpException = StatusCodeException Status ResponseHeaders CookieJar
                    | InvalidUrlException String String


### PR DESCRIPTION
Closed socket FD may be reused, so reading from or writing to it
is unsafe.

It is a fix I propose for #169

I removed the comment in `httpRedirect` because I don't think it is correct. `Bad file descriptor` occurs when the FD is closed locally, it has nothing to do with a remote side closing the connection. 

Also I added a separate `ConnectionClosed` exception instead of adding a constructor to `HttpException`. It is internal, so it should not be visible in API. I'll change it if you wish.