### PR TITLE
Derive ConnectionClosed from Typeable

### DIFF
--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -86,7 +86,7 @@ data StatusHeaders = StatusHeaders Status HttpVersion RequestHeaders
     deriving (Show, Eq, Ord, T.Typeable)
 
 data ConnectionClosed = ConnectionClosed
-  deriving (Eq, Show)
+  deriving (Eq, Show, T.Typeable)
 
 instance Exception ConnectionClosed
 


### PR DESCRIPTION
Fixes [build error on ghc 7.8](https://ci.appveyor.com/project/sapek/bond/build/1.0.506/job/d2lwmj1gut85f0k9#L381).

I don't know why this is not an error on 7.10.