### PR TITLE
Add ghc 7.8 to Travis CI matrix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,12 @@
 sudo: false
 
+matrix:
+  include:
+    - env: GHCVER=7.8.4 RESOLVER='--resolver lts-2'
+      addons: {apt: {packages: [ghc-7.8.4], sources: [hvr-ghc]}}
+    - env: GHCVER=7.10.2
+      addons: {apt: {packages: [ghc-7.10.2],sources: [hvr-ghc]}}
+    
 addons:
   apt:
     packages:
@@ -8,12 +15,12 @@ addons:
 before_install:
   # stack
   - mkdir -p ~/.local/bin
-  - export PATH=$HOME/.local/bin:/opt/ghc/7.10.1/bin:$PATH
+  - export PATH=$HOME/.local/bin:/opt/ghc/$GHCVER/bin:$PATH
   - travis_retry curl -L https://github.com/commercialhaskell/stack/releases/download/v0.1.3.1/stack-0.1.3.1-x86_64-linux.gz | gunzip > ~/.local/bin/stack
   - chmod a+x ~/.local/bin/stack
 
 script:
-  - stack +RTS -N2 -RTS --install-ghc --no-terminal test
+  - stack +RTS -N2 -RTS $RESOLVER --no-terminal test
 
 cache:
   directories:


### PR DESCRIPTION
Note that the ghc 7.8 build variant will fail because of the bug fixed with #172.