### PR TITLE
Hide catch (fix build on 7.4.2)

### DIFF
--- a/http-client/Network/HTTP/Client/Core.hs
+++ b/http-client/Network/HTTP/Client/Core.hs
@@ -12,6 +12,9 @@ module Network.HTTP.Client.Core
     , httpRedirect
     ) where
 
+#if !MIN_VERSION_base(4,6,0)
+import Prelude hiding (catch)
+#endif
 import Network.HTTP.Types
 import Network.HTTP.Client.Manager
 import Network.HTTP.Client.Types


### PR DESCRIPTION
The latest release of `http-client` fails to build on 7.4.2 due to

```
Network/HTTP/Client/Core.hs:224:21:
    Ambiguous occurrence `catch'
    It could refer to either `Prelude.catch',
                             imported from `Prelude' at Network/HTTP/Client/Core.hs:4:8-31
                             (and originally defined in `System.IO.Error')
                          or `Control.Exception.catch',
                             imported from `Control.Exception' at Network/HTTP/Client/Core.hs:23:1-24
                             (and originally defined in `Control.Exception.Base')
```

This fixes the problem simply by doing the same thing that is done in `Manager.hs`.