### PR TITLE
Enable managerModifyRequest to modify checkStatus

### DIFF
--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -215,7 +215,7 @@ responseOpenHistory req0 man = do
     reqRef <- newIORef req0
     historyRef <- newIORef id
     let go req = do
-            (req', res) <- httpRaw req man
+            (req', res) <- httpRaw' req man
             case getRedirectedRequest
                     req'
                     (responseHeaders res)
@@ -227,7 +227,7 @@ responseOpenHistory req0 man = do
                     body <- brReadSome (responseBody res) 1024
                     modifyIORef historyRef (. ((req, res { responseBody = body }):))
                     return (res, req'', True)
-    (_, res) <- httpRedirect (redirectCount req0) go req0
+    (_, res) <- httpRedirect' (redirectCount req0) go req0
     reqFinal <- readIORef reqRef
     history <- readIORef historyRef
     return HistoriedResponse

--- a/http-client/Network/HTTP/Client/Core.hs
+++ b/http-client/Network/HTTP/Client/Core.hs
@@ -22,6 +22,7 @@ import Network.HTTP.Client.Body
 import Network.HTTP.Client.Request
 import Network.HTTP.Client.Response
 import Network.HTTP.Client.Cookies
+import Data.Maybe (fromMaybe, isJust)
 import Data.Time
 import Control.Exception
 import qualified Data.ByteString as S
@@ -69,11 +70,12 @@ httpLbs req man = withResponse req man $ \res -> do
 httpNoBody :: Request -> Manager -> IO (Response ())
 httpNoBody req man = withResponse req man $ return . void
 
+
 -- | Get a 'Response' without any redirect following.
 httpRaw
      :: Request
      -> Manager
-     -> IO (Response BodyReader)
+     -> IO (Request, Response BodyReader)
 httpRaw req0 m = do
     req' <- mModifyRequest m $ mSetProxy m req0
     (req, cookie_jar') <- case cookieJar req' of
@@ -100,7 +102,8 @@ httpRaw req0 m = do
         -- Connection was reused, and might have been closed. Try again
         (Left e, Reused) | mRetryableException m e -> do
             connRelease DontReuse
-            responseOpen req m
+            res <- responseOpen req m
+            return (req, res)
         -- Not reused, or a non-retry, so this is a real exception
         (Left e, _) -> throwIO e
         -- Everything went ok, so the connection is good. If any exceptions get
@@ -109,8 +112,8 @@ httpRaw req0 m = do
             Just _ -> do
                 now' <- getCurrentTime
                 let (cookie_jar, _) = updateCookieJar res req now' cookie_jar'
-                return $ res {responseCookieJar = cookie_jar}
-            Nothing -> return res
+                return (req, res {responseCookieJar = cookie_jar})
+            Nothing -> return (req, res)
   where
 
     responseTimeout' req
@@ -150,11 +153,11 @@ httpRaw req0 m = do
 -- Since 0.1.0
 responseOpen :: Request -> Manager -> IO (Response BodyReader)
 responseOpen req0 manager = handle addTlsHostPort $ mWrapIOException manager $ do
-    res <-
+    (req, res) <-
         if redirectCount req0 == 0
             then httpRaw req0 manager
             else go (redirectCount req0) req0
-    maybe (return res) throwIO =<< applyCheckStatus req0 (checkStatus req0) res
+    maybe (return res) throwIO =<< applyCheckStatus req (checkStatus req) res
   where
     addTlsHostPort (TlsException e) = throwIO $ TlsExceptionHostPort e (host req0) (port req0)
     addTlsHostPort e = throwIO e
@@ -162,9 +165,9 @@ responseOpen req0 manager = handle addTlsHostPort $ mWrapIOException manager $ d
     go count req' = httpRedirect
       count
       (\req -> do
-        res <- httpRaw req manager
-        let mreq = getRedirectedRequest req (responseHeaders res) (responseCookieJar res) (statusCode (responseStatus res))
-        return (res, mreq))
+        (req'', res) <- httpRaw req manager
+        let mreq = getRedirectedRequest req'' (responseHeaders res) (responseCookieJar res) (statusCode (responseStatus res))
+        return (res, fromMaybe req'' mreq, isJust mreq))
       req'
 
 -- | Apply 'Request'\'s 'checkStatus' and return resulting exception if any.
@@ -205,31 +208,31 @@ applyCheckStatus req checkStatus' res =
 -- | Redirect loop
 httpRedirect
      :: Int -- ^ 'redirectCount'
-     -> (Request -> IO (Response BodyReader, Maybe Request)) -- ^ function which performs a request and returns a response, and possibly another request if there's a redirect.
+     -> (Request -> IO (Response BodyReader, Request, Bool)) -- ^ function which performs a request and returns a response, and possibly another request if there's a redirect.
      -> Request
-     -> IO (Response BodyReader)
+     -> IO (Request, Response BodyReader)
 httpRedirect count0 http' req0 = go count0 req0 []
   where
     go count _ ress | count < 0 = throwIO $ TooManyRedirects ress
     go count req' ress = do
-        (res, mreq) <- http' req'
-        case mreq of
-            Just req -> do
-                -- Allow the original connection to return to the
-                -- connection pool immediately by flushing the body.
-                -- If the response body is too large, don't flush, but
-                -- instead just close the connection.
-                let maxFlush = 1024
-                lbs <- brReadSome (responseBody res) maxFlush
-                    -- The connection may already be closed, e.g.
-                    -- when using withResponseHistory. See
-                    -- https://github.com/snoyberg/http-client/issues/169
-                    `catch` \(_ :: ConnectionClosed) -> return L.empty
-                responseClose res
+        (res, req, isRedirect) <- http' req'
+        if isRedirect then do
+            -- Allow the original connection to return to the
+            -- connection pool immediately by flushing the body.
+            -- If the response body is too large, don't flush, but
+            -- instead just close the connection.
+            let maxFlush = 1024
+            lbs <- brReadSome (responseBody res) maxFlush
+                -- The connection may already be closed, e.g.
+                -- when using withResponseHistory. See
+                -- https://github.com/snoyberg/http-client/issues/169
+                `catch` \(_ :: ConnectionClosed) -> return L.empty
+            responseClose res
 
-                -- And now perform the actual redirect
-                go (count - 1) req (res { responseBody = lbs }:ress)
-            Nothing -> return res
+            -- And now perform the actual redirect
+            go (count - 1) req (res { responseBody = lbs }:ress)
+        else
+            return (req, res)
 
 -- | Close any open resources associated with the given @Response@. In general,
 -- this will either close an active @Connection@ or return it to the @Manager@

--- a/http-client/test/Network/HTTP/ClientSpec.hs
+++ b/http-client/test/Network/HTTP/ClientSpec.hs
@@ -1,6 +1,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Network.HTTP.ClientSpec where
 
+import           Control.Exception         (toException)
 import           Network                   (withSocketsDo)
 import           Network.HTTP.Client
 import           Network.HTTP.Types        (status200)
@@ -24,3 +25,9 @@ spec = describe "Client" $ do
         withManager settings $ \man -> do
             res <- httpLbs "http://httpbin.org:1234" man
             responseStatus res `shouldBe` status200
+
+    it "managerModifyRequestCheckStatus" $ do
+        let modify req = return req { checkStatus = \s hs cj -> Just $ toException $ StatusCodeException s hs cj }
+            settings = defaultManagerSettings { managerModifyRequest = modify }
+        withManager settings $ \man ->
+            httpLbs "http://httpbin.org" man `shouldThrow` anyException


### PR DESCRIPTION
Here is the new pull request to enable ```managerModifyRequest``` to modify ```checkStatus```.

Both ```httpRaw``` and ```httpRedirect``` have been retained as-is, even the callback API of ```httpRedirect``` is unchanged.

New functions ```httpRaw'``` and ```httpRedirect'``` (incl. an extended callback API) have been added.

JFI: we also noticed that managerModifyRequest will be called multiple times in the following circumstances:

when a redirect is detected and followed (by calling httpRaw)
when a retryable error on a managed connection causes a retry (by calling responseOpen)