### PR TITLE
Fix auth via url when password contain unsafe ASCII characters 

### DIFF
--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -61,7 +61,7 @@ import Network.HTTP.Types (status200)
 import Network.HTTP.Client.Types
 import Network.HTTP.Client.Connection
 import Network.HTTP.Client.Headers (parseStatusHeaders)
-import Network.HTTP.Client.Request (username, password, applyBasicProxyAuth)
+import Network.HTTP.Client.Request (applyBasicProxyAuth, extractBasicAuthInfo)
 import Control.Concurrent.MVar (MVar, takeMVar, tryPutMVar, newEmptyMVar)
 import System.Environment (getEnvironment)
 import qualified Network.URI as U
@@ -528,14 +528,6 @@ envHelper name eh = do
                 guard $ null $ U.uriFragment uri
 
                 auth <- U.uriAuthority uri
-                let muserpass =
-                        if null authInfo
-                            then Nothing
-                            else Just ( S8.pack $ username authInfo
-                                      , S8.pack $ password authInfo
-                                      )
-                    authInfo = U.uriUserInfo auth
-
                 port <-
                     case U.uriPort auth of
                         "" -> Just 80
@@ -545,7 +537,7 @@ envHelper name eh = do
                                 _ -> Nothing
                         _ -> Nothing
 
-                Just $ (Proxy (S8.pack $ U.uriRegName auth) port, muserpass)
+                Just $ (Proxy (S8.pack $ U.uriRegName auth) port, extractBasicAuthInfo uri)
             return $ \req ->
                 if host req `hasDomainSuffixIn` noProxyDomains
                 then noEnvProxy req


### PR DESCRIPTION
Before this fix, I cannot auth via url to access http://httpbin.org/basic-auth/user/p@ss
both `simpleHttp "http://user:p@ss@httpbin.org/basic-auth/user/p@ss"`
`simpleHttp http://user:p%40ss@httpbin.org/basic-auth/user/p@ss` will failed
(the former failed due to an exception (InvalidUrlException), the later failed authentication due to encoding p%40ss again).

After this fix, `simpleHttp "http://user:p%40ss@httpbin.org/basic-auth/user/p@ss"` works.
