### PR TITLE
added missing Host: HTTP header for https CONNECT

### DIFF
--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -434,6 +434,7 @@ getConn req m
                 let ultHost = host req
                     ultPort = port req
                     proxyAuthorizationHeader = maybe "" (\h -> S8.concat ["Proxy-Authorization: ", h, "\r\n"]) . lookup "Proxy-Authorization" $ requestHeaders req
+                    hostHeader = S8.concat ["Host: ", ultHost, (S8.pack $ show ultPort), "\r\n"]
                     connstr = S8.concat
                         [ "CONNECT "
                         , ultHost
@@ -441,6 +442,7 @@ getConn req m
                         , S8.pack $ show ultPort
                         , " HTTP/1.1\r\n"
                         , proxyAuthorizationHeader
+                        , hostHeader
                         , "\r\n"
                         ]
                     parse conn = do


### PR DESCRIPTION
Hi,

I usually live behind a company firewall. stack always had problems with our firewall, e.g:

```
$ stack templates
Failed to download templates. The HTTP error was: ProxyConnectException "api.github.com" 443 (Right (StatusCodeException (Status {statusCode = 400, statusMessage = "Bad Request"}) [] (CJ {expose = []})))

```

I found out that the "Host:" HTTP header was missing in the CONNECT request message of http-client and added that.
Now stack is working fine for me.

By the way, many thanks for stack itself. It gave back some motvation to continue with haskell...

Regards,
Dieter