### PR TITLE
Fix http-client-tls link from pointing to http-client

### DIFF
--- a/http-client-tls/http-client-tls.cabal
+++ b/http-client-tls/http-client-tls.cabal
@@ -1,7 +1,7 @@
 name:                http-client-tls
 version:             0.2.4
 synopsis:            http-client backend using the connection package and tls library
-description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
+description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <https://www.stackage.org/package/http-client-tls>.
 homepage:            https://github.com/snoyberg/http-client
 license:             MIT
 license-file:        LICENSE


### PR DESCRIPTION
The change to https was just because that seemed to be the default for Stackage.org now