### PR TITLE
move status check to manager setting

### DIFF
--- a/http-client-openssl/test/Spec.hs
+++ b/http-client-openssl/test/Spec.hs
@@ -9,8 +9,9 @@ import qualified OpenSSL.Session       as SSL
 main :: IO ()
 main = withOpenSSL $ hspec $ do
     it "make a TLS connection" $ do
-        manager <- newManager $ opensslManagerSettings SSL.context
+        manager <- newManager $ (opensslManagerSettings SSL.context){
+                managerStatusCheck = \ _ _ _ -> Nothing
+            }
         withResponse "https://httpbin.org/status/418"
-            { checkStatus = \_ _ _ -> Nothing
-            } manager $ \res -> do
+            manager $ \res -> do
             responseStatus res `shouldBe` status418

--- a/http-client-tls/Network/HTTP/Client/TLS.hs
+++ b/http-client-tls/Network/HTTP/Client/TLS.hs
@@ -6,6 +6,7 @@
 module Network.HTTP.Client.TLS
     ( -- * Settings
       tlsManagerSettings
+    , tlsManagerSettings'
     , mkManagerSettings
       -- * Global manager
     , getGlobalManager
@@ -53,7 +54,7 @@ mkManagerSettings tls sock = defaultManagerSettings
                             Just NoResponseDataReceived -> True
                             Just IncompleteHeaders -> True
                             _ -> False
-    , managerWrapIOException = 
+    , managerWrapIOException =
         let wrapper se =
                 case fromException se of
                     Just e -> toException $ InternalIOException e
@@ -68,6 +69,12 @@ mkManagerSettings tls sock = defaultManagerSettings
 -- | Default TLS-enabled manager settings
 tlsManagerSettings :: ManagerSettings
 tlsManagerSettings = mkManagerSettings def Nothing
+
+-- | Default TLS-enabled manager settings
+-- but won't throw 'StatusCodeException' on non200~300 status code
+-- ('managerStatusCheck' always return 'Nothing').
+tlsManagerSettings' :: ManagerSettings
+tlsManagerSettings' = (mkManagerSettings def Nothing){managerStatusCheck = \ _ _ _ -> Nothing}
 
 getTlsConnection :: Maybe NC.TLSSettings
                  -> Maybe NC.SockSettings

--- a/http-client-tls/test/Spec.hs
+++ b/http-client-tls/test/Spec.hs
@@ -8,8 +8,7 @@ import Network.HTTP.Types
 main :: IO ()
 main = hspec $ do
     it "make a TLS connection" $ do
-        manager <- newManager tlsManagerSettings
+        manager <- newManager tlsManagerSettings'
         withResponse "https://httpbin.org/status/418"
-            { checkStatus = \_ _ _ -> Nothing
-            } manager $ \res -> do
+            manager $ \res -> do
             responseStatus res `shouldBe` status418

--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -106,12 +106,14 @@ module Network.HTTP.Client
       -- ** Connection manager settings
     , ManagerSettings
     , defaultManagerSettings
+    , defaultManagerSettings'
     , managerConnCount
     , managerRawConnection
     , managerTlsConnection
     , managerResponseTimeout
     , managerRetryableException
     , managerWrapIOException
+    , managerStatusCheck
     , managerIdleConnectionCount
     , managerModifyRequest
       -- *** Manager proxy settings
@@ -147,7 +149,6 @@ module Network.HTTP.Client
     , applyBasicProxyAuth
     , decompress
     , redirectCount
-    , checkStatus
     , responseTimeout
     , cookieJar
     , requestVersion

--- a/http-client/Network/HTTP/Client/Cookies.hs
+++ b/http-client/Network/HTTP/Client/Cookies.hs
@@ -47,7 +47,7 @@ isIpAddress =
             Just (i, x') | BS.null x' && i >= 0 && i < 256 -> go (rest - 1) y
             _ -> False
       where
-        (x, y') = BS.breakByte 46 bs -- period
+        (x, y') = BS.break (== 46) bs -- period
         y = BS.drop 1 y'
 
 -- | This corresponds to the subcomponent algorithm entitled \"Domain Matching\" detailed

--- a/http-client/Network/HTTP/Client/Core.hs
+++ b/http-client/Network/HTTP/Client/Core.hs
@@ -167,7 +167,7 @@ responseOpen req0 manager' = handle addTlsHostPort $ mWrapIOException manager $ 
         if redirectCount req0 == 0
             then httpRaw' req0 manager
             else go (redirectCount req0) req0
-    maybe (return res) throwIO =<< applyCheckStatus req (checkStatus req) res
+    maybe (return res) throwIO =<< applyCheckStatus req (mStatusCheck manager) res
   where
     manager = fromMaybe manager' (requestManagerOverride req0)
 

--- a/http-client/Network/HTTP/Client/Request.hs
+++ b/http-client/Network/HTTP/Client/Request.hs
@@ -233,10 +233,6 @@ instance Default Request where
         , rawBody = False
         , decompress = browserDecompress
         , redirectCount = 10
-        , checkStatus = \s@(W.Status sci _) hs cookie_jar ->
-            if 200 <= sci && sci < 300
-                then Nothing
-                else Just $ toException $ StatusCodeException s hs cookie_jar
         , responseTimeout = useDefaultTimeout
         , getConnectionWrapper = \mtimeout exc f ->
             case mtimeout of

--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -406,11 +406,6 @@ data Request = Request
     -- no redirects. Default value: 10.
     --
     -- Since 0.1.0
-    , checkStatus :: Status -> ResponseHeaders -> CookieJar -> Maybe SomeException
-    -- ^ Check the status code. Note that this will run after all redirects are
-    -- performed. Default: return a @StatusCodeException@ on non-2XX responses.
-    --
-    -- Since 0.1.0
     , responseTimeout :: Maybe Int
     -- ^ Number of microseconds to wait for a response. If
     -- @Nothing@, will wait indefinitely. Default: use
@@ -553,6 +548,12 @@ data ManagerSettings = ManagerSettings
     -- Default: wrap all @IOException@s in the @InternalIOException@ constructor.
     --
     -- Since 0.1.0
+    , managerStatusCheck :: Status -> ResponseHeaders -> CookieJar -> Maybe SomeException
+    -- ^ Check the status code. Note that this will run after all redirects are
+    -- performed. Default: return a @StatusCodeException@ on non-2XX responses.
+    --
+    -- Since 0.5.0
+
     , managerIdleConnectionCount :: Int
     -- ^ Total number of idle connection to keep open at a given time.
     --
@@ -615,6 +616,7 @@ data Manager = Manager
     , mTlsProxyConnection :: S.ByteString -> (Connection -> IO ()) -> String -> Maybe NS.HostAddress -> String -> Int -> IO Connection
     , mRetryableException :: SomeException -> Bool
     , mWrapIOException :: forall a. IO a -> IO a
+    , mStatusCheck :: Status -> ResponseHeaders -> CookieJar -> Maybe SomeException
     , mIdleConnectionCount :: Int
     , mModifyRequest :: Request -> IO Request
     , mSetProxy :: Request -> Request

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -1,5 +1,5 @@
 name:                http-client
-version:             0.4.28.1
+version:             0.5.0.0
 synopsis:            An HTTP client engine, intended as a base layer for more user-friendly packages.
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client

--- a/http-client/publicsuffixlist/Network/PublicSuffixList/Serialize.hs
+++ b/http-client/publicsuffixlist/Network/PublicSuffixList/Serialize.hs
@@ -35,7 +35,7 @@ getText :: BS.ByteString -> (T.Text, BS.ByteString)
 getText bs0 =
     (TE.decodeUtf8 v, BS.drop 1 bs1)
   where
-    (v, bs1) = BS.breakByte 0 bs0
+    (v, bs1) = BS.break (== 0) bs0
 
 getDataStructure :: BS.ByteString -> DataStructure
 getDataStructure bs0 =

--- a/http-client/test-nonet/Network/HTTP/ClientSpec.hs
+++ b/http-client/test-nonet/Network/HTTP/ClientSpec.hs
@@ -119,10 +119,9 @@ serveWith resp inner = bracket
 
 getChunkedResponse :: Int -> Manager -> IO (Response SL.ByteString)
 getChunkedResponse port' man = flip httpLbs man "http://localhost"
-  { port        = port'
-  , checkStatus = \_ _ _ -> Nothing
-  , requestBody = RequestBodyStreamChunked ($ return (S.replicate 100000 65))
-  }
+      { port        = port'
+      , requestBody = RequestBodyStreamChunked ($ return (S.replicate 100000 65))
+      }
 
 spec :: Spec
 spec = describe "Client" $ do
@@ -172,23 +171,23 @@ spec = describe "Client" $ do
         test True
 
     it "early close on a 413" $ earlyClose413 $ \port' -> do
-        withManager defaultManagerSettings $ \man -> do
+        withManager defaultManagerSettings' $ \man -> do
             res <- getChunkedResponse port' man
             responseBody res `shouldBe` "goodbye"
             responseStatus res `shouldBe` status413
 
     it "length zero and chunking zero #108" $ lengthZeroAndChunkZero $ \port' -> do
-        withManager defaultManagerSettings $ \man -> do
+        withManager defaultManagerSettings' $ \man -> do
             res <- getChunkedResponse port' man
             responseBody res `shouldBe` ""
 
     it "length zero and chunking" $ lengthZeroAndChunked $ \port' -> do
-        withManager defaultManagerSettings $ \man -> do
+        withManager defaultManagerSettings' $ \man -> do
             res <- getChunkedResponse port' man
             responseBody res `shouldBe` "Wikipedia in\r\n\r\nchunks."
 
     it "length and chunking" $ lengthAndChunked $ \port' -> do
-        withManager defaultManagerSettings $ \man -> do
+        withManager defaultManagerSettings' $ \man -> do
             res <- getChunkedResponse port' man
             responseBody res `shouldBe` "Wikipedia in\r\n\r\nchunks."
 

--- a/http-client/test/Network/HTTP/ClientSpec.hs
+++ b/http-client/test/Network/HTTP/ClientSpec.hs
@@ -27,11 +27,8 @@ spec = describe "Client" $ do
             responseStatus res `shouldBe` status200
 
         it "failure" $ withSocketsDo $ do
-            req' <- parseUrl "PUT http://httpbin.org/post"
-            let req = req'
-                    { checkStatus = \_ _ _ -> Nothing
-                    }
-            man <- newManager defaultManagerSettings
+            req <- parseUrl "PUT http://httpbin.org/post"
+            man <- newManager defaultManagerSettings'
             res <- httpLbs req man
             responseStatus res `shouldBe` status405
 
@@ -43,7 +40,8 @@ spec = describe "Client" $ do
             responseStatus res `shouldBe` status200
 
     it "managerModifyRequestCheckStatus" $ do
-        let modify req = return req { checkStatus = \s hs cj -> Just $ toException $ StatusCodeException s hs cj }
-            settings = defaultManagerSettings { managerModifyRequest = modify }
+        let settings = defaultManagerSettings {
+                    managerStatusCheck = \s hs cj -> Just $ toException $ StatusCodeException s hs cj
+                }
         withManager settings $ \man ->
             httpLbs "http://httpbin.org" man `shouldThrow` anyException

--- a/http-conduit/Network/HTTP/Conduit.hs
+++ b/http-conduit/Network/HTTP/Conduit.hs
@@ -169,7 +169,6 @@ module Network.HTTP.Conduit
     , rawBody
     , decompress
     , redirectCount
-    , checkStatus
     , responseTimeout
     , cookieJar
     , requestVersion

--- a/http-conduit/Network/HTTP/Simple.hs
+++ b/http-conduit/Network/HTTP/Simple.hs
@@ -53,7 +53,6 @@ module Network.HTTP.Simple
     , setRequestBodyFile
     , setRequestBodyURLEncoded
       -- ** Special fields
-    , setRequestIgnoreStatus
     , setRequestBasicAuth
     , setRequestManager
     , setRequestProxy
@@ -321,13 +320,6 @@ setRequestBodyFile = setRequestBody . HI.RequestBodyIO . H.streamFile
 -- @since 2.1.10
 setRequestBodyURLEncoded :: [(S.ByteString, S.ByteString)] -> H.Request -> H.Request
 setRequestBodyURLEncoded = H.urlEncodedBody
-
--- | Modify the request so that non-2XX status codes do not generate a runtime
--- exception.
---
--- @since 2.1.10
-setRequestIgnoreStatus :: H.Request -> H.Request
-setRequestIgnoreStatus req = req { H.checkStatus = \_ _ _ -> Nothing }
 
 -- | Set basic auth with the given username and password
 --

--- a/http-conduit/http-conduit.cabal
+++ b/http-conduit/http-conduit.cabal
@@ -30,7 +30,7 @@ library
                  , conduit-extra         >= 1.1.5
                  , http-types            >= 0.7
                  , lifted-base           >= 0.1
-                 , http-client           >= 0.4.28  && < 0.5
+                 , http-client           >= 0.4.28  && < 0.6
                  , http-client-tls       >= 0.2.4
                  , monad-control
                  , mtl


### PR DESCRIPTION
respond to #193 , disable status check is very common in many places, so it should be part of manager setting. The only problem is that this patch is a breaking change. @snoyberg please judge on this.