### PR TITLE
Changed order of socket connect and socket tweak.

### DIFF
--- a/http-client/Network/HTTP/Client/Connection.hs
+++ b/http-client/Network/HTTP/Client/Connection.hs
@@ -165,8 +165,8 @@ openSocketConnectionSize tweakSocket chunksize hostAddress host port = do
             (NS.sClose)
             (\sock -> do
                 NS.setSocketOption sock NS.NoDelay 1
-                NS.connect sock (NS.addrAddress addr)
                 tweakSocket sock
+                NS.connect sock (NS.addrAddress addr)
                 socketConnection sock chunksize)
 
 firstSuccessful :: [NS.AddrInfo] -> (NS.AddrInfo -> IO a) -> IO a

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -1,5 +1,5 @@
 name:                http-client
-version:             0.4.29
+version:             0.4.30
 synopsis:            An HTTP client engine, intended as a base layer for more user-friendly packages.
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client


### PR DESCRIPTION
Hi,

I've changed the order of connecting and tweaking sockets. My use case is to perform 'bind' on a client connection in order to bind it to a specific interface. Binding must be performed before connecting. For the setting of general socket options - which I guess is the main use case for the tweaking callback - this change should not matter, to the best of my understanding.

Cheers,
  --patrik

From commit comments:

When creating a Manager a callback can be registered using the
rawConnectionModifySocket helper function. The order when this
callback is called is changed. Now the callback is called before
the socket connection has opened. Some operations, e.g. a source
address bind, cannot be performed on connected sockets.