### PR TITLE
Added length validation for RequestBodyStream

### DIFF
--- a/http-client/Network/HTTP/Client/Request.hs
+++ b/http-client/Network/HTTP/Client/Request.hs
@@ -396,9 +396,7 @@ requestBuilder req Connection {..} = do
                     if isChunked then connectionWrite "0\r\n\r\n"
                     -- If not chunked, then length argument is present
                     -- and should be validated
-                    else if ( fromJust mlen == n) 
-                             then return ()
-                             else throwIO $ WrongRequestBodyStreamSize (fromIntegral . fromJust $ mlen) (fromIntegral n)
+                    else unless (fromJust mlen == n) $ throwIO $ WrongRequestBodyStreamSize (fromIntegral . fromJust $ mlen) (fromIntegral n)
                 else do
                     connectionWrite $
                         if isChunked

--- a/http-client/Network/HTTP/Client/Request.hs
+++ b/http-client/Network/HTTP/Client/Request.hs
@@ -396,9 +396,9 @@ requestBuilder req Connection {..} = do
                     if isChunked then connectionWrite "0\r\n\r\n"
                     -- If not chunked, then length argument is present
                     -- and should be validated
-                    else if ( fromJust mlen /= n) 
-                             then throwIO $ WrongRequestBodyStreamSize (fromIntegral . fromJust $ mlen) (fromIntegral n)
-                             else return ()
+                    else if ( fromJust mlen == n) 
+                             then return ()
+                             else throwIO $ WrongRequestBodyStreamSize (fromIntegral . fromJust $ mlen) (fromIntegral n)
                 else do
                     connectionWrite $
                         if isChunked

--- a/http-client/Network/HTTP/Client/Request.hs
+++ b/http-client/Network/HTTP/Client/Request.hs
@@ -392,11 +392,11 @@ requestBuilder req Connection {..} = do
         loop !n stream = do
             bs <- stream
             if S.null bs
-                then 
-                    if isChunked then connectionWrite "0\r\n\r\n"
-                    -- If not chunked, then length argument is present
-                    -- and should be validated
-                    else unless (fromJust mlen == n) $ throwIO $ WrongRequestBodyStreamSize (fromIntegral . fromJust $ mlen) (fromIntegral n)
+                then case mlen of 
+                    -- If stream is chunked, no length argument
+                    Nothing -> connectionWrite "0\r\n\r\n"
+                    -- Not chunked - validate length argument
+                    Just len -> unless (len == n) $ throwIO $ WrongRequestBodyStreamSize (fromIntegral len) (fromIntegral n)
                 else do
                     connectionWrite $
                         if isChunked

--- a/http-client/Network/HTTP/Client/Request.hs
+++ b/http-client/Network/HTTP/Client/Request.hs
@@ -29,7 +29,7 @@ module Network.HTTP.Client.Request
     ) where
 
 import Data.Int (Int64)
-import Data.Maybe (fromMaybe, fromJust, isJust, isNothing)
+import Data.Maybe (fromMaybe, isJust, isNothing)
 import Data.Monoid (mempty, mappend)
 import Data.String (IsString(..))
 import Data.Char (toLower)
@@ -387,8 +387,6 @@ requestBuilder req Connection {..} = do
     writeStream mlen withStream =
         withStream (loop 0) 
       where
-        -- When stream is chunked, no length is provided 
-        isChunked = isNothing mlen
         loop !n stream = do
             bs <- stream
             if S.null bs
@@ -399,7 +397,7 @@ requestBuilder req Connection {..} = do
                     Just len -> unless (len == n) $ throwIO $ WrongRequestBodyStreamSize (fromIntegral len) (fromIntegral n)
                 else do
                     connectionWrite $
-                        if isChunked
+                        if (isNothing mlen) -- Chunked
                             then S.concat
                                 [ S8.pack $ showHex (S.length bs) "\r\n"
                                 , bs

--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -119,6 +119,8 @@ data HttpException = StatusCodeException Status ResponseHeaders CookieJar
                    | NoResponseDataReceived
                    | TlsException SomeException
                    | TlsNotSupported
+                   | WrongRequestBodyStreamSize Word64 Word64
+                   -- ^ Expected size/actual size
                    | ResponseBodyTooShort Word64 Word64
                    -- ^ Expected size/actual size.
                    --


### PR DESCRIPTION
This is proposed fix for #204. Tested with my code to verify that the error doesn't happen any more in case of wrong length, and that when the length is correct, data upload goes through.

I repurposed `writeStream` machinery and added `length` check for when chunking is false - not elegant solution :( 

Now, there is an additional branch - pseudo-code changes in bold below -
Before: if isChunked then return terminator else return ()
After: if isChunked then return terminator else **(if length error return 400 status code else return ())**

Not sure if Status code 400 is right one here. It seems to be appropriate for client-side error, to me.

If anything needs to be changed, please do let me know. 