### PR TITLE
Enable managerModifyRequest to modify redirectCount

### DIFF
--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -229,10 +229,11 @@ data HistoriedResponse body = HistoriedResponse
 --
 -- Since 0.4.1
 responseOpenHistory :: Request -> Manager -> IO (HistoriedResponse BodyReader)
-responseOpenHistory req0 man = handle (throwIO . toHttpException req0) $ do
+responseOpenHistory req0 man0 = handle (throwIO . toHttpException req0) $ do
     reqRef <- newIORef req0
     historyRef <- newIORef id
-    let go req = do
+    let go req0 = do
+            (man, req) <- getModifiedRequestManager man0 req0
             (req', res') <- httpRaw' req man
             let res = res'
                     { responseBody = handle (throwIO . toHttpException req0)


### PR DESCRIPTION
This changes the behavior of `httpRaw` and `httpRaw'`: They will not apply `mModifyRequest` on given requests. (Since they are only exported in `Internal` modules I hope this is ok.)

I'm not very happy with this code (apart from the test case). How the request is modified has gotten very confusing. This is also very visible in the confusing non-informative names for the requests (`req0`, `req`, `req'`, `req''` and now `inputReq`). I'm not very familiar with this code internally, so I'm not sure how to refactor things without breaking other features. I may look into this in the next days, but any pointers (or code) would be appreciated.

One more concrete question: Does it even makes sense that `httpRaw'` returns a `Request` if it doesn't apply `mModifyRequest` to it anymore?