### PR TITLE
http-conduit: Fix bounds for http-client-tls

### DIFF
--- a/http-conduit/http-conduit.cabal
+++ b/http-conduit/http-conduit.cabal
@@ -31,7 +31,7 @@ library
                  , http-types            >= 0.7
                  , lifted-base           >= 0.1
                  , http-client           >= 0.5     && < 0.6
-                 , http-client-tls       >= 0.2.4
+                 , http-client-tls       >= 0.3     && < 0.4
                  , monad-control
                  , mtl
                  , exceptions            >= 0.6


### PR DESCRIPTION
I had a compilation failure with http-conduit-2.2.0 and http-client-tls-0.2.4