### PR TITLE
Add benchmark for newManager

### DIFF
--- a/http-client-tls/bench/Bench.hs
+++ b/http-client-tls/bench/Bench.hs
@@ -1,0 +1,15 @@
+module Main where
+
+import Criterion.Main
+import Network.HTTP.Client
+import Network.HTTP.Client.TLS
+
+main :: IO ()
+main = defaultMain [
+      bgroup "newManager" [
+            bench "defaultManagerSettings" $
+                whnfIO (newManager defaultManagerSettings)
+          , bench "tlsManagerSettings" $
+                whnfIO (newManager tlsManagerSettings)
+          ]
+    ]

--- a/http-client-tls/http-client-tls.cabal
+++ b/http-client-tls/http-client-tls.cabal
@@ -35,3 +35,13 @@ test-suite spec
                      , http-client
                      , http-client-tls
                      , http-types
+
+benchmark benchmark
+  main-is:             Bench.hs
+  type:                exitcode-stdio-1.0
+  hs-source-dirs:      bench
+  default-language:    Haskell2010
+  build-depends:       base
+                     , criterion
+                     , http-client
+                     , http-client-tls


### PR DESCRIPTION
Timings from my rather slow machine:

```
benchmarking newManager/defaultManagerSettings
time                 982.3 μs   (937.2 μs .. 1.011 ms)
                     0.991 R²   (0.988 R² .. 0.994 R²)
mean                 868.4 μs   (846.3 μs .. 895.4 μs)
std dev              77.42 μs   (64.40 μs .. 94.70 μs)
variance introduced by outliers: 69% (severely inflated)

benchmarking newManager/tlsManagerSettings
time                 13.95 ms   (13.50 ms .. 14.41 ms)
                     0.994 R²   (0.990 R² .. 0.998 R²)
mean                 15.06 ms   (14.73 ms .. 15.38 ms)
std dev              791.0 μs   (666.8 μs .. 973.5 μs)
variance introduced by outliers: 23% (moderately inflated)
```