### PR TITLE
Global connection context

### DIFF
--- a/http-client-tls/Network/HTTP/Client/TLS.hs
+++ b/http-client-tls/Network/HTTP/Client/TLS.hs
@@ -40,7 +40,7 @@ import Data.ByteArray.Encoding (convertToBase, Base (Base16))
 mkManagerSettings :: NC.TLSSettings
                   -> Maybe NC.SockSettings
                   -> ManagerSettings
-mkManagerSettings = mkManagerSettingsContext Nothing
+mkManagerSettings = mkManagerSettingsContext (Just globalContext)
 
 -- | Same as 'mkManagerSettings', but also takes an optional
 -- 'NC.ConnectionContext'. Providing this externally can be an
@@ -84,6 +84,10 @@ mkManagerSettingsContext mcontext tls sock = defaultManagerSettings
 -- | Default TLS-enabled manager settings
 tlsManagerSettings :: ManagerSettings
 tlsManagerSettings = mkManagerSettings def Nothing
+
+globalContext :: NC.ConnectionContext
+globalContext = unsafePerformIO NC.initConnectionContext
+{-# NOINLINE globalContext #-}
 
 getTlsConnection :: Maybe NC.ConnectionContext
                  -> Maybe NC.TLSSettings


### PR DESCRIPTION
Pinging @sjakobi and @vincenthz. This is intended to speed up manager creation (#214). However, I'm not sure how safe it is to have a global connection context like this. @vincenthz can you weigh in on this approach? Once I get an idea of the semantics of this, I'll clean up this commit and ask for a second review.
