### PR TITLE
Add missing colon in Host header

### DIFF
--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -419,7 +419,7 @@ getConn req m
                 let ultHost = host req
                     ultPort = port req
                     proxyAuthorizationHeader = maybe "" (\h' -> S8.concat ["Proxy-Authorization: ", h', "\r\n"]) . lookup "Proxy-Authorization" $ requestHeaders req
-                    hostHeader = S8.concat ["Host: ", ultHost, (S8.pack $ show ultPort), "\r\n"]
+                    hostHeader = S8.concat ["Host: ", ultHost, ":", (S8.pack $ show ultPort), "\r\n"]
                     connstr = S8.concat
                         [ "CONNECT "
                         , ultHost


### PR DESCRIPTION
I think there is a missing colon here when setting Host header while using https proxy.