### PR TITLE
Modify response

### DIFF
--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -108,6 +108,7 @@ module Network.HTTP.Client
     , managerWrapException
     , managerIdleConnectionCount
     , managerModifyRequest
+    , managerModifyResponse
       -- *** Manager proxy settings
     , managerSetProxy
     , managerSetInsecureProxy

--- a/http-client/Network/HTTP/Client/Body.hs
+++ b/http-client/Network/HTTP/Client/Body.hs
@@ -7,6 +7,7 @@ module Network.HTTP.Client.Body
     , makeUnlimitedReader
     , brConsume
     , brEmpty
+    , constBodyReader
     , brAddCleanup
     , brReadSome
     , brRead
@@ -51,6 +52,14 @@ brReadSome brRead' =
 
 brEmpty :: BodyReader
 brEmpty = return S.empty
+
+constBodyReader :: [S.ByteString] -> IO BodyReader
+constBodyReader input = do
+  iinput <- newIORef input
+  return $ atomicModifyIORef iinput $ \input' ->
+        case input' of
+            [] -> ([], S.empty)
+            x:xs -> (xs, x)
 
 brAddCleanup :: IO () -> BodyReader -> BodyReader
 brAddCleanup cleanup brRead' = do

--- a/http-client/Network/HTTP/Client/Core.hs
+++ b/http-client/Network/HTTP/Client/Core.hs
@@ -196,7 +196,7 @@ responseOpen inputReq manager' = do
   wrapExc req0 $ mWrapException manager req0 $ do
     (req, res) <- go manager (redirectCount req0) req0
     checkResponse req req res
-    return res
+    mModifyResponse manager res
         { responseBody = wrapExc req0 (responseBody res)
         }
   where

--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -110,6 +110,7 @@ defaultManagerSettings = ManagerSettings
          in handle wrapper
     , managerIdleConnectionCount = 512
     , managerModifyRequest = return
+    , managerModifyResponse = return
     , managerProxyInsecure = defaultProxy
     , managerProxySecure = defaultProxy
     }
@@ -194,6 +195,7 @@ newManager ms = do
             , mWrapException = managerWrapException ms
             , mIdleConnectionCount = managerIdleConnectionCount ms
             , mModifyRequest = managerModifyRequest ms
+            , mModifyResponse = managerModifyResponse ms
             , mSetProxy = \req ->
                 if secure req
                     then httpsProxy req

--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -675,6 +675,12 @@ data ManagerSettings = ManagerSettings
     -- Default: no modification
     --
     -- Since 0.4.4
+    , managerModifyResponse :: Response BodyReader -> IO (Response BodyReader)
+    -- ^ Perform the given modification to a @Response@ after receiving it.
+    --
+    -- Default: no modification
+    --
+    -- Since 0.5.5
     , managerProxyInsecure :: ProxyOverride
     -- ^ How HTTP proxy server settings should be discovered.
     --
@@ -724,6 +730,7 @@ data Manager = Manager
     , mIdleConnectionCount :: Int
     , mModifyRequest :: Request -> IO Request
     , mSetProxy :: Request -> Request
+    , mModifyResponse      :: Response BodyReader -> IO (Response BodyReader)
     -- ^ See 'managerProxy'
     }
     deriving T.Typeable


### PR DESCRIPTION
Add a `modifyResponse` hook similar to the one for `Request` modification.

It expects a function of type `Response BodyReader -> IO (Response BodyReader)` that will be executed just after `checkResponse` was called.

This will allow to implement #248 outside of the http-client library.

Unfortunately, and that is why I still put a WiP in front, my test for body modification does not run through. @snoyberg Any idea what I am doing wrong?