### PR TITLE
Issue #153: Added socks5 and socks5h support; tests pass

### DIFF
--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -509,6 +509,8 @@ envHelper name eh = do
             (p, muserpass) <- maybe invalid return $ do
                 uri <- case U.parseURI str of
                     Just u | U.uriScheme u == "http:" -> return u
+                           | U.uriScheme u == "socks5:" -> return u
+                           | U.uriScheme u == "socks5h:" -> return u
                     _ -> U.parseURI $ "http://" ++ str
 
                 guard $ U.uriScheme uri == "http:"


### PR DESCRIPTION
I didn't see exactly how to test the usage of a SOCKS5 proxy via the environment variable -- everything that I saw said that it just should work. If you point me in the direction of how to write a test, I'm happy to do so.