### PR TITLE
Allow creating a TLS-based Manager using specified settings

### DIFF
--- a/http-client-tls/ChangeLog.md
+++ b/http-client-tls/ChangeLog.md
@@ -1,3 +1,10 @@
+## 0.3.5
+
+* Add `newTlsManagerWith`
+  [#278](https://github.com/snoyberg/http-client/issues/278), which
+  provides a variant of `newTlsManager` that takes a `ManagerSettings`
+  to base its settings off of.
+
 ## 0.3.4.2
 
 * Never throw exceptions on 401 status in `applyDigestAuth`

--- a/http-client-tls/Network/HTTP/Client/TLS.hs
+++ b/http-client-tls/Network/HTTP/Client/TLS.hs
@@ -12,6 +12,7 @@ module Network.HTTP.Client.TLS
     , mkManagerSettings
     , mkManagerSettingsContext
     , newTlsManager
+    , newTlsManagerWith
       -- * Digest authentication
     , applyDigestAuth
     , DigestAuthException (..)
@@ -70,16 +71,17 @@ mkManagerSettingsContext
     -> NC.TLSSettings
     -> Maybe NC.SockSettings
     -> ManagerSettings
-mkManagerSettingsContext mcontext tls sock = mkManagerSettingsContext' mcontext tls sock sock
+mkManagerSettingsContext mcontext tls sock = mkManagerSettingsContext' defaultManagerSettings mcontext tls sock sock
 
 -- | Internal, allow different SockSettings for HTTP and HTTPS
 mkManagerSettingsContext'
-    :: Maybe NC.ConnectionContext
+    :: ManagerSettings
+    -> Maybe NC.ConnectionContext
     -> NC.TLSSettings
     -> Maybe NC.SockSettings -- ^ insecure
     -> Maybe NC.SockSettings -- ^ secure
     -> ManagerSettings
-mkManagerSettingsContext' mcontext tls sockHTTP sockHTTPS = defaultManagerSettings
+mkManagerSettingsContext' set mcontext tls sockHTTP sockHTTPS = set
     { managerTlsConnection = getTlsConnection mcontext (Just tls) sockHTTPS
     , managerTlsProxyConnection = getTlsProxyConnection mcontext tls sockHTTPS
     , managerRawConnection =
@@ -177,12 +179,17 @@ globalConnectionContext = unsafePerformIO NC.initConnectionContext
 --
 -- @since 0.3.4
 newTlsManager :: MonadIO m => m Manager
-newTlsManager = liftIO $ do
+newTlsManager = newTlsManagerWith defaultManagerSettings
+
+-- | Load up a new TLS manager based upon specified settings,
+-- respecting proxy environment variables.
+newTlsManagerWith :: MonadIO m => ManagerSettings -> m Manager
+newTlsManagerWith set = liftIO $ do
     env <- getEnvironment
     let lenv = Map.fromList $ map (first $ T.toLower . T.pack) env
         msocksHTTP = parseSocksSettings env lenv "http_proxy"
         msocksHTTPS = parseSocksSettings env lenv "https_proxy"
-        settings = mkManagerSettingsContext' (Just globalConnectionContext) def msocksHTTP msocksHTTPS
+        settings = mkManagerSettingsContext' set (Just globalConnectionContext) def msocksHTTP msocksHTTPS
         settings' = maybe id (const $ managerSetInsecureProxy proxyFromRequest) msocksHTTP
                   $ maybe id (const $ managerSetSecureProxy proxyFromRequest) msocksHTTPS
                     settings

--- a/http-client-tls/Network/HTTP/Client/TLS.hs
+++ b/http-client-tls/Network/HTTP/Client/TLS.hs
@@ -183,6 +183,8 @@ newTlsManager = newTlsManagerWith defaultManagerSettings
 
 -- | Load up a new TLS manager based upon specified settings,
 -- respecting proxy environment variables.
+--
+-- @since 0.3.5
 newTlsManagerWith :: MonadIO m => ManagerSettings -> m Manager
 newTlsManagerWith set = liftIO $ do
     env <- getEnvironment

--- a/http-client-tls/http-client-tls.cabal
+++ b/http-client-tls/http-client-tls.cabal
@@ -1,5 +1,5 @@
 name:                http-client-tls
-version:             0.3.4.2
+version:             0.3.5
 synopsis:            http-client backend using the connection package and tls library
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <https://www.stackage.org/package/http-client-tls>.
 homepage:            https://github.com/snoyberg/http-client


### PR DESCRIPTION
For example, to allow for a different timeout.

Closes #278