### PR TITLE
Clarify docs regarding throwing on non-2XX requests

### DIFF
--- a/http-client/Network/HTTP/Client/Request.hs
+++ b/http-client/Network/HTTP/Client/Request.hs
@@ -109,7 +109,9 @@ parseUrlThrow =
 -- Note that the request method must be provided as all capital letters.
 --
 -- 'Request' created by this function won't cause exceptions on non-2XX
--- response status codes.
+-- response status codes. 
+--
+-- To create a request which throws on non-2XX status codes, see 'parseUrlThrow'
 --
 -- @since 0.4.30
 parseRequest :: MonadThrow m => String -> m Request

--- a/http-conduit/Network/HTTP/Simple.hs
+++ b/http-conduit/Network/HTTP/Simple.hs
@@ -15,6 +15,8 @@
 -- >
 -- > main :: IO ()
 -- > main = httpLBS "http://example.com" >>= L8.putStrLn
+--
+-- The `Data.String.IsString` instance uses `H.parseRequest` behind the scenes and inherits its behavior.
 module Network.HTTP.Simple
     ( -- * Perform requests
       httpLBS


### PR DESCRIPTION
The docs for Network.HTTP.Simple were vague regarding what happens with non-2XX requests. 

Both `parseRequest` and `setRequestIgnoreStatus` allow you to *disable* throwing on non-2XX, which suggests the default behavior is to throw. The `IsString` didn't specify what function it was using behind the scenes, suggesting that you could create a throwing request using it (which was not the case as I found out later)

This PR adds clarification on the `IsString` behavior being the same as `parseRequest`, and also adds a note into `parseRequest` pointing at the correct function to use.