### PR TITLE
Remove withSocketsDo from documentation and testing

### DIFF
--- a/http-client/Network/HTTP/Client/MultipartFormData.hs
+++ b/http-client/Network/HTTP/Client/MultipartFormData.hs
@@ -10,7 +10,7 @@
 -- >
 -- > import Control.Monad
 -- >
--- > main = withSocketsDo $ void $ withManager defaultManagerSettings $ \m -> do
+-- > main = void $ withManager defaultManagerSettings $ \m -> do
 -- >     req1 <- parseRequest "http://random-cat-photo.net/cat.jpg"
 -- >     res <- httpLbs req1 m
 -- >     req2 <- parseRequest "http://example.org/~friedrich/blog/addPost.hs"

--- a/http-client/test/Network/HTTP/ClientSpec.hs
+++ b/http-client/test/Network/HTTP/ClientSpec.hs
@@ -1,7 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 module Network.HTTP.ClientSpec where
 
-import           Network                   (withSocketsDo)
 import qualified Data.ByteString.Char8        as BS
 import           Network.HTTP.Client
 import           Network.HTTP.Client.Internal
@@ -16,20 +15,20 @@ main = hspec spec
 
 spec :: Spec
 spec = describe "Client" $ do
-    it "works" $ withSocketsDo $ do
+    it "works" $ do
         req <- parseUrlThrow "http://httpbin.org/"
         man <- newManager defaultManagerSettings
         res <- httpLbs req man
         responseStatus res `shouldBe` status200
 
     describe "method in URL" $ do
-        it "success" $ withSocketsDo $ do
+        it "success" $ do
             req <- parseUrlThrow "POST http://httpbin.org/post"
             man <- newManager defaultManagerSettings
             res <- httpLbs req man
             responseStatus res `shouldBe` status200
 
-        it "failure" $ withSocketsDo $ do
+        it "failure" $ do
             req <- parseRequest "PUT http://httpbin.org/post"
             man <- newManager defaultManagerSettings
             res <- httpLbs req man

--- a/http-conduit/Network/HTTP/Conduit.hs
+++ b/http-conduit/Network/HTTP/Conduit.hs
@@ -87,7 +87,7 @@
 -- >                 , cookie_http_only = False
 -- >                 }
 -- >
--- > main = withSocketsDo $ do
+-- > main = do
 -- >      request' <- parseRequest "http://example.com/secret-page"
 -- >      manager <- newManager tlsManagerSettings
 -- >      let request = request' { cookieJar = Just $ createCookieJar [cookie] }
@@ -98,19 +98,6 @@
 -- >                        then (putStrLn "login failed" >> return Nothing)
 -- >                        else return Nothing
 -- >                  _ -> E.throw ex)
---
--- Any network code on Windows requires some initialization, and the network
--- library provides withSocketsDo to perform it. Therefore, proper usage of
--- this library will always involve calling that function at some point.  The
--- best approach is to simply call them at the beginning of your main function,
--- such as:
---
--- > import Network.HTTP.Conduit
--- > import qualified Data.ByteString.Lazy as L
--- > import Network (withSocketsDo)
--- >
--- > main = withSocketsDo
--- >      $ simpleHttp "http://www.haskell.org/" >>= L.putStr
 --
 -- Cookies are implemented according to RFC 6265.
 --
@@ -124,7 +111,7 @@
 -- > import Network
 -- >
 -- > main :: IO ()
--- > main = withSocketsDo $ do
+-- > main = do
 -- >      request' <- parseRequest "http://www.yesodweb.com/does-not-exist"
 -- >      let request = request' { checkStatus = \_ _ _ -> Nothing }
 -- >      manager <- newManager tlsManagerSettings

--- a/http-conduit/test.hs
+++ b/http-conduit/test.hs
@@ -16,7 +16,7 @@ mproxify sockshost req
 	| otherwise       = req { socksProxy = Just $ defaultSocksConf sockshost 1080 }
 
 main :: IO ()
-main = withSocketsDo $ do
+main = do
     [url] <- getArgs
     proxy <- catch (getEnv "SOCKS_PROXY") (const $ return "")
     _req2 <- mproxify proxy `fmap` parseUrl url

--- a/http-conduit/test/main.hs
+++ b/http-conduit/test/main.hs
@@ -20,7 +20,6 @@ import Network.HTTP.Types
 import Control.Exception.Lifted (try, SomeException, bracket, onException, IOException)
 import qualified Data.IORef as I
 import qualified Control.Exception as E (catch)
-import Network (withSocketsDo)
 import Network.Socket (sClose)
 import qualified Network.BSD
 import CookieTest (cookieTest)
@@ -172,7 +171,7 @@ withAppTls' app' f = do
         sendResponse res
 
 main :: IO ()
-main = withSocketsDo $ do
+main = do
   mapM_ (`hSetBuffering` LineBuffering) [stdout, stderr]
   hspec $ do
     cookieTest


### PR DESCRIPTION
Since #107 `withSocketsDo` has been unnecessary, but it's still used in the test suite, and still documented. This PR fixes that.

I tested things, and confirmed they got no worse on Windows (0 http-conduit failures, 5 http-client failures), although the test suite is broken there (see #111) so it isn't fully checked, but it should be fine.