### PR TITLE
Make sure that proper headers are passed before JSON HTTP call

### DIFF
--- a/http-conduit/ChangeLog.md
+++ b/http-conduit/ChangeLog.md
@@ -1,3 +1,7 @@
+## 2.2.3.2
+
+* Add proper headers for `httpJSON` and `httpJSONEither` [#284](https://github.com/snoyberg/http-client/issues/284)
+
 ## 2.2.3.1
 
 * Minor README improvement

--- a/http-conduit/http-conduit.cabal
+++ b/http-conduit/http-conduit.cabal
@@ -1,5 +1,5 @@
 name:            http-conduit
-version:         2.2.3.1
+version:         2.2.3.2
 license:         BSD3
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Since the functions parses the body as JSON, it is appropriate to set
the Accept header to be application/json indicating the server that
the client wants JSON in response.

Also application/json is recognized as a standard MIME media type:
https://tools.ietf.org/html/rfc4627#section-6

This patch will fix snoyberg#284