### PR TITLE
Don't modify request n+1 times

### DIFF
--- a/http-client/Network/HTTP/Client/Core.hs
+++ b/http-client/Network/HTTP/Client/Core.hs
@@ -194,7 +194,7 @@ responseOpen :: Request -> Manager -> IO (Response BodyReader)
 responseOpen inputReq manager' = do
   (manager, req0) <- getModifiedRequestManager manager' inputReq
   wrapExc req0 $ mWrapException manager req0 $ do
-    (req, res) <- go manager (redirectCount req0) req0
+    (req, res) <- go manager (redirectCount req0) inputReq
     checkResponse req req res
     mModifyResponse manager res
         { responseBody = wrapExc req0 (responseBody res)

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -90,6 +90,8 @@ test-suite spec
                      , zlib
                      , async
                      , streaming-commons >= 0.1.1
+                     , aeson
+                     , unordered-containers
 
 
 test-suite spec-nonet


### PR DESCRIPTION
There was a use case where a colleague created a `Manager` to send
authorized requests by appending the header field `Authorization: Bearer
...` to the list of a request header fields list, using the
`managerModifyRequest` setting. The server replied with 401 errors even
if the token was valid. The reason is that `managerModifyRequest`
function was applied twice and the server was interpreting the duplicate
`Authorization` header field as a value that is defined as a
comma-separated list. According to section 4.2 Message Headers of RFC
2616:

> Multiple message-header fields with the same field-name MAY be
> present in a message if and only if the entire field-value for that
> header field is defined as a comma-separated list [i.e., #(values)].
> It MUST be possible to combine the multiple header fields into one
> "field-name: field-value" pair, without changing the semantics of the
> message, by appending each subsequent field-value to the first, each
> separated by a comma. The order in which header fields with the same
> field-name are received is therefore significant to the
> interpretation of the combined field value, and thus a proxy MUST NOT
> change the order of these field values when a message is forwarded.

In `responseOpen` the first application of `getModifiedRequestManager`
is useful to pass a consistent request value to `wrapExc` and to pass
the correct value of redirect count to the first application of
`httpRedirect'` in `go manager (redirectCount req0) req0`, but I think
that using `req0` as the last argument was redundant because `go`
applies again `getModifiedRequestManager` in the block that is used as
the second parameter of `httpRedirect'`.

Note about the new test case: I added a test that sends a request to
httpbin.org/headers and parses the response to check that the client
doesn't send the same header n+1 times. Unfortunately httpbin.org
mistakenly removes duplicate header fields, see kennethreitz/httpbin#355,
so I had to use request's `redirectCount` as an accumulator to send two
different header fields.