### PR TITLE
Support proxy for openssl

### DIFF
--- a/http-client-openssl/ChangeLog.md
+++ b/http-client-openssl/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.2.1.0
+
+* Add support for http-proxy
+
 ## 0.2.0.5
 
 * Use different domain name so tests pass

--- a/http-client-openssl/Network/HTTP/Client/OpenSSL.hs
+++ b/http-client-openssl/Network/HTTP/Client/OpenSSL.hs
@@ -49,4 +49,32 @@ opensslManagerSettings mkContext = defaultManagerSettings
                         (SSL.read ssl 32752)
                         (SSL.write ssl)
                         (N.close sock)
+    , managerTlsProxyConnection = do
+        ctx <- mkContext
+        return $ \connstr checkConn serverName _ha host port -> do
+            -- Copied/modified from openssl-streams
+            let hints      = N.defaultHints
+                                { N.addrFlags      = [N.AI_ADDRCONFIG, N.AI_NUMERICSERV]
+                                , N.addrFamily     = N.AF_INET
+                                , N.addrSocketType = N.Stream
+                                }
+            (addrInfo:_) <- N.getAddrInfo (Just hints) (Just host) (Just $ show port)
+
+            let family     = N.addrFamily addrInfo
+            let socketType = N.addrSocketType addrInfo
+            let protocol   = N.addrProtocol addrInfo
+            let address    = N.addrAddress addrInfo
+
+            bracketOnError (N.socket family socketType protocol) (N.close)
+                $ \sock -> do
+                    N.connect sock address
+                    conn <- socketConnection sock 32752
+                    connectionWrite conn connstr
+                    checkConn conn
+                    ssl <- SSL.connection ctx sock
+                    SSL.connect ssl
+                    makeConnection
+                        (SSL.read ssl 32752)
+                        (SSL.write ssl)
+                        (N.close sock)
     }

--- a/http-client-openssl/http-client-openssl.cabal
+++ b/http-client-openssl/http-client-openssl.cabal
@@ -12,6 +12,10 @@ build-type:          Simple
 cabal-version:       >=1.10
 extra-source-files:  README.md ChangeLog.md
 
+flag test-proxy
+   description: Test with http-proxy
+   default: False
+
 library
   exposed-modules:     Network.HTTP.Client.OpenSSL
   other-extensions:    ScopedTypeVariables
@@ -27,6 +31,8 @@ test-suite spec
   hs-source-dirs:      test
   default-language:    Haskell2010
   ghc-options:         -threaded
+  if flag(test-proxy)
+    cpp-options: -DUSE_PROXY
   build-depends:       base
                      , hspec
                      , http-client >= 0.4.30

--- a/http-client-openssl/http-client-openssl.cabal
+++ b/http-client-openssl/http-client-openssl.cabal
@@ -1,5 +1,5 @@
 name:                http-client-openssl
-version:             0.2.0.5
+version:             0.2.1.0
 synopsis:            http-client backend using the OpenSSL library.
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client

--- a/http-client-openssl/test/Spec.hs
+++ b/http-client-openssl/test/Spec.hs
@@ -1,4 +1,5 @@
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE CPP #-}
 import Test.Hspec
 import Network.HTTP.Client
 import Network.HTTP.Client.OpenSSL
@@ -13,3 +14,12 @@ main = withOpenSSL $ hspec $ do
         withResponse (parseRequest_ "HEAD https://s3.amazonaws.com/hackage.fpcomplete.com/01-index.tar.gz") manager $ \res -> do
             responseStatus res `shouldBe` status200
             lookup "content-type" (responseHeaders res) `shouldBe` Just "application/x-gzip"
+#ifdef USE_PROXY
+    it "make a TLS connection with proxy" $ do
+        manager <- newManager $ opensslManagerSettings SSL.context
+        let req = addProxy "localhost" 8080 $
+                  parseRequest_ "HEAD https://s3.amazonaws.com/hackage.fpcomplete.com/01-index.tar.gz"
+        withResponse req manager $ \res -> do
+            responseStatus res `shouldBe` status200
+            lookup "content-type" (responseHeaders res) `shouldBe` Just "application/x-gzip"
+#endif


### PR DESCRIPTION
Hi,

This PR supports http-proxy for openssl.
The test-flag(test-proxy of cabal)  is off by default.

