### PR TITLE
Fix a proxy-connection-bug for openssl

### DIFF
--- a/http-client-openssl/ChangeLog.md
+++ b/http-client-openssl/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.2.1.1
+
+* Fix a connection-bug with http-proxy(Previous version closes a connection before reading all respose-data.)
+
 ## 0.2.1.0
 
 * Add support for http-proxy

--- a/http-client-openssl/Network/HTTP/Client/OpenSSL.hs
+++ b/http-client-openssl/Network/HTTP/Client/OpenSSL.hs
@@ -11,6 +11,7 @@ import Network.HTTP.Client
 import Network.HTTP.Client.Internal
 import Control.Exception
 import Network.Socket (HostAddress)
+import Network.Socket.ByteString (sendAll, recv)
 import OpenSSL
 import qualified Network.Socket as N
 import qualified OpenSSL.Session       as SSL
@@ -68,7 +69,10 @@ opensslManagerSettings mkContext = defaultManagerSettings
             bracketOnError (N.socket family socketType protocol) (N.close)
                 $ \sock -> do
                     N.connect sock address
-                    conn <- socketConnection sock 32752
+                    conn <- makeConnection
+                            (recv sock 32752)
+                            (sendAll sock)
+                            (return ())
                     connectionWrite conn connstr
                     checkConn conn
                     ssl <- SSL.connection ctx sock

--- a/http-client-openssl/http-client-openssl.cabal
+++ b/http-client-openssl/http-client-openssl.cabal
@@ -1,5 +1,5 @@
 name:                http-client-openssl
-version:             0.2.1.0
+version:             0.2.1.1
 synopsis:            http-client backend using the OpenSSL library.
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client

--- a/http-client-openssl/test/Spec.hs
+++ b/http-client-openssl/test/Spec.hs
@@ -22,4 +22,12 @@ main = withOpenSSL $ hspec $ do
         withResponse req manager $ \res -> do
             responseStatus res `shouldBe` status200
             lookup "content-type" (responseHeaders res) `shouldBe` Just "application/x-gzip"
+    it "compare responses without and with proxy" $ do
+        manager <- newManager $ opensslManagerSettings SSL.context
+        let req = parseRequest_ "GET https://raw.githubusercontent.com/snoyberg/http-client/master/README.md"
+        v_org <- withResponse req manager $ \res -> do
+          lbsResponse res
+        v <- withResponse (addProxy "localhost" 8080 req) manager $ \res -> do
+          lbsResponse res
+        (responseBody v) `shouldBe` (responseBody v_org)
 #endif


### PR DESCRIPTION
Hi,

https://github.com/snoyberg/http-client/pull/298 sometimes fails,
because [this connection](https://github.com/snoyberg/http-client/blob/master/http-client-openssl/Network/HTTP/Client/OpenSSL.hs#L71) closes before SSL_read does not finishes.

This PR fixes the code and adds a test for response-body.
The test's result is below.
```
$ stack test --flag http-client-openssl:test-proxy
http-client-openssl-0.2.1.1: test (suite: spec)


make a TLS connection
make a TLS connection with proxy
compare responses without and with proxy

Finished in 5.4022 seconds
3 examples, 0 failures
````