### PR TITLE
Switch from network to socket

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ cabal.sandbox.config
 .stack-work/
 tarballs/
 *~
+*.hp
+*.prof

--- a/http-client/Network/HTTP/Client/Connection.hs
+++ b/http-client/Network/HTTP/Client/Connection.hs
@@ -16,9 +16,7 @@ import Data.ByteString (ByteString, empty)
 import Data.IORef
 import Control.Monad
 import Network.HTTP.Client.Types
-import Network.Socket (Socket, HostAddress)
-import qualified Network.Socket as NS
-import Network.Socket.ByteString (sendAll, recv)
+import qualified Network.HTTP.Client.Socket as NS
 import qualified Control.Exception as E
 import qualified Data.ByteString as S
 import Data.Word (Word8)
@@ -123,24 +121,24 @@ makeConnection r w c = do
 -- | Create a new 'Connection' from a 'Socket'.
 --
 -- @since 0.5.3
-socketConnection :: Socket
+socketConnection :: NS.Socket
                  -> Int -- ^ chunk size
                  -> IO Connection
 socketConnection socket chunksize = makeConnection
-    (recv socket chunksize)
-    (sendAll socket)
+    (NS.recv socket chunksize)
+    (NS.sendAll socket)
     (NS.close socket)
 
-openSocketConnection :: (Socket -> IO ())
-                     -> Maybe HostAddress
+openSocketConnection :: (NS.Socket -> IO ())
+                     -> Maybe NS.HostAddress
                      -> String -- ^ host
                      -> Int -- ^ port
                      -> IO Connection
 openSocketConnection f = openSocketConnectionSize f 8192
 
-openSocketConnectionSize :: (Socket -> IO ())
+openSocketConnectionSize :: (NS.Socket -> IO ())
                          -> Int -- ^ chunk size
-                         -> Maybe HostAddress
+                         -> Maybe NS.HostAddress
                          -> String -- ^ host
                          -> Int -- ^ port
                          -> IO Connection

--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -35,7 +35,7 @@ import Control.Exception (mask_, catch, throwIO, fromException, mask, IOExceptio
 import Control.Concurrent (forkIO, threadDelay)
 import Data.Time (UTCTime (..), getCurrentTime, addUTCTime)
 
-import qualified Network.Socket as NS
+import qualified Network.HTTP.Client.Socket as NS
 
 import System.Mem.Weak (Weak, deRefWeak)
 import Network.HTTP.Types (status200)

--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -398,7 +398,7 @@ getConn req m
             _ -> (Nothing, HostName $ T.pack connhost)
 
     wrapConnectExc = handle $ \e ->
-        throwHttp $ ConnectionFailure (toException (e :: IOException))
+        throwHttp $ ConnectionFailure (toException (e :: NS.SocketException))
     go =
         case (secure req, useProxy') of
             (False, _) -> mRawConnection m

--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -50,14 +50,14 @@ import Control.Concurrent.MVar (MVar, takeMVar, tryPutMVar, newEmptyMVar)
 -- use case, see: <https://github.com/snoyberg/http-client/issues/71>.
 --
 -- Since 0.3.8
-rawConnectionModifySocket :: (NS.Socket -> IO ())
+rawConnectionModifySocket :: (NS.Socket' -> IO ())
                           -> IO (Maybe NS.HostAddress -> String -> Int -> IO Connection)
 rawConnectionModifySocket = return . openSocketConnection
 
 -- | Same as @rawConnectionModifySocket@, but also takes in a chunk size.
 --
 -- @since 0.5.2
-rawConnectionModifySocketSize :: (NS.Socket -> IO ())
+rawConnectionModifySocketSize :: (NS.Socket' -> IO ())
                               -> IO (Int -> Maybe NS.HostAddress -> String -> Int -> IO Connection)
 rawConnectionModifySocketSize = return . openSocketConnectionSize
 
@@ -158,7 +158,6 @@ addToList now maxCount x l@(Cons _ currCount _ _)
 -- Since 0.1.0
 newManager :: ManagerSettings -> IO Manager
 newManager ms = do
-    NS.withSocketsDo $ return ()
     rawConnection <- managerRawConnection ms
     tlsConnection <- managerTlsConnection ms
     tlsProxyConnection <- managerTlsProxyConnection ms

--- a/http-client/Network/HTTP/Client/Socket.hs
+++ b/http-client/Network/HTTP/Client/Socket.hs
@@ -1,0 +1,7 @@
+module Network.HTTP.Client.Socket
+  ( module Network.Socket
+  , module Network.Socket.ByteString
+  ) where
+
+import Network.Socket hiding (recv, recvFrom, send, sendTo)
+import Network.Socket.ByteString

--- a/http-client/Network/HTTP/Client/Socket.hs
+++ b/http-client/Network/HTTP/Client/Socket.hs
@@ -1,7 +1,19 @@
 module Network.HTTP.Client.Socket
-  ( module Network.Socket
-  , module Network.Socket.ByteString
+  ( module Network.HTTP.Client.Socket
+  , module System.Socket
+  , module System.Socket.Family.Inet
+  , module System.Socket.Protocol.TCP
+  , module System.Socket.Type.Stream
   ) where
 
-import Network.Socket hiding (recv, recvFrom, send, sendTo)
-import Network.Socket.ByteString
+import Data.Word
+import System.Socket
+import System.Socket.Family.Inet
+import System.Socket.Protocol.TCP
+import System.Socket.Type.Stream
+
+type AddrInfo = AddressInfo Inet Stream TCP
+
+type HostAddress = (Word8, Word8, Word8, Word8)
+
+type Socket' = Socket Inet Stream TCP

--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -51,9 +51,8 @@ import Data.String (IsString, fromString)
 import Data.Time (UTCTime)
 import Data.Traversable (Traversable)
 import qualified Data.List as DL
-import Network.Socket (HostAddress)
 import Data.IORef
-import qualified Network.Socket as NS
+import qualified Network.HTTP.Client.Socket as NS
 import qualified Data.IORef as I
 import qualified Data.Map as Map
 import Data.Text (Text)
@@ -476,7 +475,7 @@ data Request = Request
     -- ^ Optional HTTP proxy.
     --
     -- Since 0.1.0
-    , hostAddress :: Maybe HostAddress
+    , hostAddress :: Maybe NS.HostAddress
     -- ^ Optional resolved host address. May not be used by all backends.
     --
     -- Since 0.1.0

--- a/http-client/bench/gh-306.hs
+++ b/http-client/bench/gh-306.hs
@@ -1,0 +1,50 @@
+-- This is a small benchmark meant to see how fast the http-client library can
+-- make requests. In particular, it's meant to compare the network library and
+-- the socket library. <https://github.com/snoyberg/http-client/pull/306>
+
+import qualified Control.Concurrent.Async as Async
+import qualified Control.Monad as Monad
+import qualified Data.Text as Text
+import qualified Data.Text.Encoding as Text
+import qualified Data.Text.Lazy as LazyText
+import qualified Data.Text.Lazy.Encoding as LazyText
+import qualified Data.Time as Time
+import qualified Network.HTTP.Client as Client
+import qualified Network.HTTP.Types as Http
+import qualified Network.Wai as Wai
+import qualified Network.Wai.Handler.Warp as Warp
+import qualified Text.Printf as Printf
+
+main :: IO ()
+main = do
+  let
+    status = Http.status200
+    body = LazyText.encodeUtf8 (LazyText.pack "null")
+    port = 8080
+    server = Warp.run port (\ _ respond -> respond (Wai.responseLBS
+      status
+      [(Http.hContentType, Text.encodeUtf8 (Text.pack "application/json"))]
+      body))
+    threads = 4
+    count = 10000
+
+  thread <- Async.async server
+  request <- Client.parseRequest ("http://localhost:" ++ show port)
+  manager <- Client.newManager Client.defaultManagerSettings
+  start <- Time.getCurrentTime
+  Async.replicateConcurrently_ threads (Monad.replicateM_ count (do
+    response <- Client.httpLbs request manager
+    Monad.guard (Client.responseStatus response == status)
+    Monad.guard (Client.responseBody response == body)))
+  end <- Time.getCurrentTime
+  Async.cancel thread
+
+  let elapsed = Time.diffUTCTime end start
+  let rate = fromIntegral count / realToFrac elapsed
+  Printf.printf
+    "%d threads\n\
+    \%d requests per thread\n\
+    \%.1f requests per second\n"
+    threads
+    count
+    (rate :: Double)

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -43,7 +43,7 @@ library
                      , http-types        >= 0.8
                      , blaze-builder     >= 0.3
                      , time              >= 1.2
-                     , network           >= 2.4
+                     , socket            >= 0.8.0   && < 0.9
                      , streaming-commons >= 0.1.0.2 && < 0.2
                      , containers
                      , transformers
@@ -58,7 +58,7 @@ library
                      , mime-types
                      , ghc-prim
   if flag(network-uri)
-    build-depends: network >= 2.6, network-uri >= 2.6
+    build-depends: network-uri >= 2.6
   else
     build-depends: network < 2.6
 

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -29,6 +29,7 @@ library
                        Network.HTTP.Client.Manager
                        Network.HTTP.Client.Request
                        Network.HTTP.Client.Response
+                       Network.HTTP.Client.Socket
                        Network.HTTP.Client.Types
                        Network.HTTP.Client.Util
                        Network.HTTP.Proxy

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -125,3 +125,19 @@ test-suite spec-nonet
                      , async
                      , streaming-commons >= 0.1.1
                      , directory
+
+benchmark gh-306
+  build-depends:
+    async,
+    base,
+    http-client,
+    http-types,
+    text,
+    time,
+    wai,
+    warp
+  default-language: Haskell2010
+  ghc-options: -O2 -rtsopts -threaded -Wall -with-rtsopts=-N
+  hs-source-dirs: bench
+  main-is: gh-306.hs
+  type: exitcode-stdio-1.0


### PR DESCRIPTION
This pull request explores switching from the venerable [`network`](https://hackage.haskell.org/package/network) package to @lpeterse's [`socket`](https://hackage.haskell.org/package/socket) package. The switch turned out to be easier than I expected. Nevertheless, a few of the tests fail:

```
  test-nonet/Network/HTTP/ClientSpec.hs:188: 
  1) Network.HTTP.Client.Client early close on a 413
       uncaught exception: SocketException (ePipe)

  test-nonet/Network/HTTP/ClientSpec.hs:194: 
  2) Network.HTTP.Client.Client length zero and chunking zero #108
       uncaught exception: SocketException (ePipe)

  test-nonet/Network/HTTP/ClientSpec.hs:199: 
  3) Network.HTTP.Client.Client length zero and chunking
       uncaught exception: SocketException (ePipe)

  test-nonet/Network/HTTP/ClientSpec.hs:204: 
  4) Network.HTTP.Client.Client length and chunking
       uncaught exception: SocketException (eProtocolType)
```

I didn't spend much time trying to debug those because they seem to rely on [`streaming-commons`](https://hackage.haskell.org/package/streaming-commons), which itself depends on `network` and exposes `Socket`s. 

My goal here isn't actually to replace `network` with `socket` — at least not right away. I wanted to see if it was possible and how it affected performance (since `socket` uses `MVar`s behind the scenes). Sadly I don't have an off-the-shelf way to measure the performance of `http-client`. I'll have to look around for one unless someone has a better idea. I tried running `http-client/bench/threaded-stress.hs`, but after bringing it up to date I realized it doesn't really stress test the sockets. 

cc @eborden @snoyberg 