### PR TITLE
Update example at top

### DIFF
--- a/http-conduit/Network/HTTP/Simple.hs
+++ b/http-conduit/Network/HTTP/Simple.hs
@@ -14,7 +14,7 @@
 -- > import qualified Data.ByteString.Lazy.Char8 as L8
 -- >
 -- > main :: IO ()
--- > main = httpLBS "http://example.com" >>= L8.putStrLn
+-- > main = httpLBS "http://example.com" >>= L8.putStrLn . L8.pack . show
 --
 -- The `Data.String.IsString` instance uses `H.parseRequest` behind the scenes and inherits its behavior.
 module Network.HTTP.Simple

--- a/http-conduit/Network/HTTP/Simple.hs
+++ b/http-conduit/Network/HTTP/Simple.hs
@@ -14,7 +14,7 @@
 -- > import qualified Data.ByteString.Lazy.Char8 as L8
 -- >
 -- > main :: IO ()
--- > main = httpLBS "http://example.com" >>= L8.putStrLn . L8.pack . show
+-- > main = httpLBS "http://example.com" >>= L8.putStrLn . getResponseBody
 --
 -- The `Data.String.IsString` instance uses `H.parseRequest` behind the scenes and inherits its behavior.
 module Network.HTTP.Simple


### PR DESCRIPTION
The original example wouldn't type check due to the result being `Response L8.ByteString` instead of just `L8.ByteString`. Compiler error here:
```
• Couldn't match type ‘Response L8.ByteString’ with ‘L8.ByteString’
      Expected type: Response L8.ByteString -> IO ()
        Actual type: L8.ByteString -> IO ()
    • In the second argument of ‘(>>=)’, namely ‘L8.putStrLn’
      In the expression: httpLBS "http://example.com" >>= L8.putStrLn
      In an equation for ‘main’:
          main = httpLBS "http://example.com" >>= L8.putStrLn
```

Proposed the change of using `L8.pack . show` to encode the `Response`. Could also do something simpler such `getResponseBody` to just display the body of the response. Not sure which would be better to display for someone arriving to the library.