### PR TITLE
Redacts Authorization header content from Show Request

### DIFF
--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -3,6 +3,7 @@
 {-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE OverloadedStrings #-}
 module Network.HTTP.Client.Types
     ( BodyReader
     , Connection (..)
@@ -56,6 +57,7 @@ import Data.Text (Text)
 import Data.Streaming.Zlib (ZlibException)
 import Data.CaseInsensitive as CI
 import Data.KeyedPool (KeyedPool)
+import Control.Applicative((<$>))
 
 -- | An @IO@ action that represents an incoming response body coming from the
 -- server. Data provided by this action has already been gunzipped and
@@ -554,7 +556,7 @@ instance Show Request where
         , "  host                 = " ++ show (host x)
         , "  port                 = " ++ show (port x)
         , "  secure               = " ++ show (secure x)
-        , "  requestHeaders       = " ++ show (requestHeaders x)
+        , "  requestHeaders       = " ++ show (redactSensitiveHeader <$> requestHeaders x)
         , "  path                 = " ++ show (path x)
         , "  queryString          = " ++ show (queryString x)
         --, "  requestBody          = " ++ show (requestBody x)
@@ -566,6 +568,10 @@ instance Show Request where
         , "  requestVersion       = " ++ show (requestVersion x)
         , "}"
         ]
+
+redactSensitiveHeader :: Header -> Header
+redactSensitiveHeader ("Authorization", value) = ("Authorization", "<REDACTED>")
+redactSensitiveHeader h = h
 
 -- | A simple representation of the HTTP response.
 --

--- a/http-client/test-nonet/Network/HTTP/Client/RequestSpec.hs
+++ b/http-client/test-nonet/Network/HTTP/Client/RequestSpec.hs
@@ -10,6 +10,8 @@ import Network.HTTP.Client.Internal
 import Network.URI (URI(..), URIAuth(..), parseURI)
 import Test.Hspec
 import Data.Monoid ((<>))
+import Network.HTTP.Client (defaultRequest)
+import Data.List (isInfixOf)
 
 spec :: Spec
 spec = do
@@ -36,6 +38,11 @@ spec = do
         (uriRegName $ fromJust $ uriAuthority $ getUri $ fromJust request) `shouldBe` requestHostnameWithoutAuth
         field `shouldSatisfy` isJust
         field `shouldBe` Just "Basic dXNlcjpwYXNz"
+
+    describe "Show Request" $
+      it "redacts authorization header content" $ do
+        let request = defaultRequest { requestHeaders = [("Authorization", "secret")] }
+        isInfixOf "secret" (show request) `shouldBe` False
 
     describe "applyBasicProxyAuth" $ do
         let request = applyBasicProxyAuth "user" "pass" <$> parseUrlThrow "http://example.org"


### PR DESCRIPTION
As the Authorization header content is usually sensitive tokens and `Show Request` is usually used in logging.