### PR TITLE
Correct lower-bounds

### DIFF
--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -37,7 +37,7 @@ library
                        Network.PublicSuffixList.Serialize
                        Network.PublicSuffixList.DataStructure
                        Data.KeyedPool
-  build-depends:       base              >= 4.5    && < 5
+  build-depends:       base              >= 4.6    && < 5
                      , bytestring        >= 0.10
                      , text              >= 0.11
                      , http-types        >= 0.8
@@ -45,7 +45,7 @@ library
                      , time              >= 1.2
                      , network           >= 2.4
                      , streaming-commons >= 0.1.0.2 && < 0.3
-                     , containers
+                     , containers        >= 0.5
                      , transformers
                      , deepseq           >= 1.3    && <1.5
                      , case-insensitive  >= 1.0
@@ -57,7 +57,7 @@ library
                      , filepath
                      , mime-types
                      , ghc-prim
-                     , stm
+                     , stm               >= 2.3
   if flag(network-uri)
     build-depends: network >= 2.6, network-uri >= 2.6
   else


### PR DESCRIPTION
- base: `Prelude.catch` and `Control.Exception.catch` are different in
  `base-4.5`
- containers: There are uses of `Data.Map.Strict`, present in
  `containers-0.5.*` only
- stm: `swapTVar` is there only from `stm-2.3`

looks like GHC-7.6.3 is commented out on travis, please bump the lower-bound for base (to `base >= 4.7`) if you don't plan to support GHC-7.6 in the future releases

I made this revision to latest release on Hackage: https://hackage.haskell.org/package/http-client-0.5.8/revisions/