### PR TITLE
Keep original TLS settings when creating a manager using newTlsManagerWith

### DIFF
--- a/http-client-tls/ChangeLog.md
+++ b/http-client-tls/ChangeLog.md
@@ -1,3 +1,6 @@
+* [#289](https://github.com/snoyberg/http-client/issues/289):
+  Keep original `TLSSettings` when creating a `Manager` using `newTlsManagerWith`.
+
 ## 0.3.5.1
 
 * Also catch TLSError exceptions [#273](https://github.com/snoyberg/http-client/pull/273)

--- a/http-client-tls/Network/HTTP/Client/TLS.hs
+++ b/http-client-tls/Network/HTTP/Client/TLS.hs
@@ -196,6 +196,14 @@ newTlsManagerWith set = liftIO $ do
         settings' = maybe id (const $ managerSetInsecureProxy proxyFromRequest) msocksHTTP
                   $ maybe id (const $ managerSetSecureProxy proxyFromRequest) msocksHTTPS
                     settings
+                        -- We want to keep the original TLS settings that were
+                        -- passed in. Sadly they aren't available as a record
+                        -- field on `ManagerSettings`. So instead we grab the
+                        -- fields that depend on the TLS settings.
+                        -- https://github.com/snoyberg/http-client/issues/289
+                        { managerTlsConnection = managerTlsConnection set
+                        , managerTlsProxyConnection = managerTlsProxyConnection set
+                        }
     newManager settings'
 
 parseSocksSettings :: [(String, String)] -- ^ original environment

--- a/http-client-tls/http-client-tls.cabal
+++ b/http-client-tls/http-client-tls.cabal
@@ -41,6 +41,7 @@ test-suite spec
   hs-source-dirs:      test
   default-language:    Haskell2010
   build-depends:       base
+                     , connection
                      , hspec
                      , http-client
                      , http-client-tls

--- a/http-client-tls/test/Spec.hs
+++ b/http-client-tls/test/Spec.hs
@@ -1,5 +1,6 @@
 {-# LANGUAGE OverloadedStrings #-}
 import Test.Hspec
+import Network.Connection
 import Network.HTTP.Client
 import Network.HTTP.Client.TLS
 import Network.HTTP.Types
@@ -27,3 +28,19 @@ main = hspec $ do
         join (applyDigestAuth "user" "passwd" "http://httpbin.org/" man)
             `shouldThrow` \(DigestAuthException _ _ det) ->
                 det == UnexpectedStatusCode
+
+    -- https://github.com/snoyberg/http-client/issues/289
+    it "accepts TLS settings" $ do
+        let
+          tlsSettings = TLSSettingsSimple
+            { settingDisableCertificateValidation = True
+            , settingDisableSession = False
+            , settingUseServerName = False
+            }
+          socketSettings = Nothing
+          managerSettings = mkManagerSettings tlsSettings socketSettings
+        manager <- newTlsManagerWith managerSettings
+        let url = "https://wrong.host.badssl.com"
+        request <- parseRequest url
+        response <- httpNoBody request manager
+        responseStatus response `shouldBe` status200


### PR DESCRIPTION
This fixes #289. 

I hoped that `ManagerSettings` would have a field for its `TLSSettings`, but unfortunately it doesn't. Instead of adding such a field and using it here, I chose to copy over the fields that are derived from the `TLSSettings` instead. This way I don't have to change the core `ManagerSettings` data type. The downside is that if any more fields depend on the `TLSSettings`, it's unlikely that `newTlsManagerWith` will also end up being updated. 

:pager: @ivan-m 