### PR TITLE
Add missing `build-tools` dependency specification

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,10 @@
+-- See http://cabal.readthedocs.io/en/latest/nix-local-build-overview.html for more information
+
+packages:
+  http-client
+  http-client-tls
+  http-client-openssl
+  http-conduit
+
+tests: True
+benchmarks: True

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -77,6 +77,7 @@ test-suite spec
   hs-source-dirs:      test
   default-language:    Haskell2010
   other-modules:       Network.HTTP.ClientSpec
+  build-tools:         hspec-discover
   build-depends:       base
                      , http-client
                      , hspec
@@ -109,6 +110,7 @@ test-suite spec-nonet
                        Network.HTTP.Client.RequestSpec
                        Network.HTTP.Client.RequestBodySpec
                        Network.HTTP.Client.CookieSpec
+  build-tools:         hspec-discover
   build-depends:       base
                      , http-client
                      , hspec


### PR DESCRIPTION
also provides cabal project configuration file