### PR TITLE
Switch out `base64-bytestring` for `memory`

### DIFF
--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -49,7 +49,7 @@ library
                      , transformers
                      , deepseq           >= 1.3    && <1.5
                      , case-insensitive  >= 1.0
-                     , base64-bytestring >= 1.0    && <1.1
+                     , memory            >= 0.14
                      , cookie
                      , exceptions        >= 0.4
                      , array
@@ -91,7 +91,6 @@ test-suite spec
                      , transformers
                      , deepseq
                      , case-insensitive
-                     , base64-bytestring
                      , zlib
                      , async
                      , streaming-commons >= 0.1.1
@@ -127,7 +126,6 @@ test-suite spec-nonet
                      , transformers
                      , deepseq
                      , case-insensitive
-                     , base64-bytestring
                      , zlib
                      , async
                      , streaming-commons >= 0.1.1


### PR DESCRIPTION
> It's probably worth switching over anyway.  — @snoyberg

I'm not sure what the policy is here on upper bounds since there are some upper bounds but not many. I went with the predominant style.