### PR TITLE
Fix non-TLS connections going though proxy

### DIFF
--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -1,6 +1,7 @@
 ## 0.5.12
 
 * Added `requestFromURI` and `requestFromURI_` functions.
+* Fixed non-TLS connections going though proxy [#337](https://github.com/snoyberg/http-client/issues/337)
 
 ## 0.5.11
 

--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -218,12 +218,14 @@ connKey req =
         Nothing
             | secure req -> simple CKSecure
             | otherwise -> simple CKRaw
-        Just p -> CKProxy
-            (proxyHost p)
-            (proxyPort p)
-            (lookup "Proxy-Authorization" (requestHeaders req))
-            (host req)
-            (port req)
+        Just p
+            | secure req -> CKProxy
+                (proxyHost p)
+                (proxyPort p)
+                (lookup "Proxy-Authorization" (requestHeaders req))
+                (host req)
+                (port req)
+            | otherwise -> CKRaw Nothing (proxyHost p) (proxyPort p)
   where
     simple con = con (hostAddress req) (host req) (port req)
 


### PR DESCRIPTION
Looking at source code from [0.5.7.1](https://github.com/snoyberg/http-client/blob/http-client/0.5.7.1/http-client/Network/HTTP/Client/Manager.hs) (notably functions `getConn` and `getConnDest`) this should restore the previous behavior.

The part I left is the modification of pooling key from commit 8c24f7dbf7c083ece6cc467b3a4fcc35e4727a4e. I'm not sure if that one is necessary.