### PR TITLE
Removed unused extensions

### DIFF
--- a/http-client-openssl/Network/HTTP/Client/OpenSSL.hs
+++ b/http-client-openssl/Network/HTTP/Client/OpenSSL.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE ScopedTypeVariables #-}
 -- | Support for making connections via the OpenSSL library.
 module Network.HTTP.Client.OpenSSL
     ( opensslManagerSettings

--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -1,6 +1,4 @@
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveTraversable #-}
-{-# LANGUAGE DeriveFoldable #-}
 {-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE CPP #-}

--- a/http-client/Network/HTTP/Client/Core.hs
+++ b/http-client/Network/HTTP/Client/Core.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE CPP #-}
 {-# LANGUAGE OverloadedStrings #-}
 module Network.HTTP.Client.Core
     ( withResponse

--- a/http-client/Network/HTTP/Client/Headers.hs
+++ b/http-client/Network/HTTP/Client/Headers.hs
@@ -1,6 +1,6 @@
+{-# LANGUAGE DisambiguateRecordFields #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE RecordWildCards   #-}
-{-# LANGUAGE ViewPatterns      #-}
+{-# LANGUAGE ViewPatterns #-}
 module Network.HTTP.Client.Headers
     ( parseStatusHeaders
     ) where

--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -1,9 +1,6 @@
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE BangPatterns #-}
 {-# LANGUAGE RankNTypes #-}
+{-# LANGUAGE ScopedTypeVariables #-}
 module Network.HTTP.Client.Manager
     ( ManagerSettings (..)
     , newManager

--- a/http-client/Network/HTTP/Client/MultipartFormData.hs
+++ b/http-client/Network/HTTP/Client/MultipartFormData.hs
@@ -1,4 +1,4 @@
-{-# LANGUAGE CPP, OverloadedStrings #-}
+{-# LANGUAGE OverloadedStrings #-}
 -- | This module handles building multipart/form-data. Example usage:
 --
 -- > {-# LANGUAGE OverloadedStrings #-}

--- a/http-client/Network/HTTP/Client/Response.hs
+++ b/http-client/Network/HTTP/Client/Response.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE RecordWildCards #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP #-}
+{-# LANGUAGE RecordWildCards #-}
 module Network.HTTP.Client.Response
     ( getRedirectedRequest
     , getResponse

--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -1,7 +1,5 @@
 {-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveDataTypeable #-}
-{-# LANGUAGE DeriveFoldable #-}
-{-# LANGUAGE DeriveFunctor #-}
 {-# LANGUAGE DeriveTraversable #-}
 {-# LANGUAGE RankNTypes #-}
 {-# LANGUAGE OverloadedStrings #-}

--- a/http-client/Network/HTTP/Client/Util.hs
+++ b/http-client/Network/HTTP/Client/Util.hs
@@ -1,9 +1,5 @@
-{-# LANGUAGE CPP #-}
-{-# LANGUAGE DeriveDataTypeable #-}
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE TupleSections #-}
 module Network.HTTP.Client.Util
     ( readDec
     ) where

--- a/http-conduit/Network/HTTP/Client/Conduit.hs
+++ b/http-conduit/Network/HTTP/Client/Conduit.hs
@@ -1,6 +1,5 @@
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE RankNTypes            #-}
+{-# LANGUAGE FlexibleContexts #-}
+{-# LANGUAGE RankNTypes #-}
 -- | A new, experimental API to replace "Network.HTTP.Conduit".
 --
 -- For most users, "Network.HTTP.Simple" is probably a better choice. For more

--- a/http-conduit/Network/HTTP/Conduit.hs
+++ b/http-conduit/Network/HTTP/Conduit.hs
@@ -1,7 +1,5 @@
-{-# LANGUAGE CPP                   #-}
-{-# LANGUAGE FlexibleContexts      #-}
-{-# LANGUAGE MultiParamTypeClasses #-}
-{-# LANGUAGE OverloadedStrings     #-}
+{-# LANGUAGE FlexibleContexts  #-}
+{-# LANGUAGE OverloadedStrings #-}
 -- |
 --
 -- = Simpler API

--- a/http-conduit/test.hs
+++ b/http-conduit/test.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE CPP #-}
 import Network.HTTP.Conduit
 import Network
 import qualified Data.ByteString as S


### PR DESCRIPTION
Removed most unused extensions from every module. This has been done using the OrganizeExtensions refactoring of the Haskell-Tools framework. See http://www.haskelltools.org/