### PR TITLE
Request bodies in LBS

### DIFF
--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -171,6 +171,7 @@ module Network.HTTP.Client
     , streamFile
     , observedStreamFile
     , StreamFileStatus (..)
+    , requestBodyLBS
       -- * Response
     , Response
     , responseStatus

--- a/http-client/Network/HTTP/Client/Request.hs
+++ b/http-client/Network/HTTP/Client/Request.hs
@@ -33,6 +33,7 @@ module Network.HTTP.Client.Request
     , streamFile
     , observedStreamFile
     , extractBasicAuthInfo
+    , requestBodyLBS
     ) where
 
 import Data.Int (Int64)
@@ -554,3 +555,7 @@ observedStreamFile obs path = do
             k (filePopper h)
 
     return $ RequestBodyStream size givesFilePopper
+
+-- | Get the request body lazy bytestring
+requestBodyLBS :: RequestBody -> L.ByteString
+requestBodyLBS (RequestBodyLBS lbs) = lbs

--- a/http-client/Network/HTTP/Client/Request.hs
+++ b/http-client/Network/HTTP/Client/Request.hs
@@ -558,4 +558,4 @@ observedStreamFile obs path = do
 
 -- | Get the request body lazy bytestring
 requestBodyLBS :: RequestBody -> L.ByteString
-requestBodyLBS (RequestBodyLBS lbs) = lbs
+requestBodyLBS (RequestBodyLBS body) = body

--- a/http-conduit/Network/HTTP/Simple.hs
+++ b/http-conduit/Network/HTTP/Simple.hs
@@ -58,6 +58,7 @@ module Network.HTTP.Simple
     , setRequestBodySource
     , setRequestBodyFile
     , setRequestBodyURLEncoded
+    , getRequestBodyLBS
       -- ** Special fields
     , H.setRequestIgnoreStatus
     , setRequestBasicAuth
@@ -386,6 +387,10 @@ setRequestBodyFile = setRequestBody . HI.RequestBodyIO . H.streamFile
 -- @since 2.1.10
 setRequestBodyURLEncoded :: [(S.ByteString, S.ByteString)] -> H.Request -> H.Request
 setRequestBodyURLEncoded = H.urlEncodedBody
+
+-- | Get the request body lazy bytestring
+getRequestBodyLBS :: H.Request -> L.ByteString
+getRequestBodyLBS = H.requestBodyLBS . H.requestBody
 
 -- | Set basic auth with the given username and password
 --


### PR DESCRIPTION
Sometimes you need to use a request body as a string. But work with RequestBody doesn't simple.
So i add in http-client a function to get lazy bytestring from it.
And i add in http-conduit (Network.HTTP.Simple) a function that takes request and use http-client function to do the same.
They work only with RequestBodyLBS constructor.