### PR TITLE
Add more functions for throwing StatusCodeException #304

### DIFF
--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -1,3 +1,8 @@
+## 0.5.13
+
+* Adds `setRequestCheckStatus` and `throwErrorStatusCodes` functions.
+  See [#304](https://github.com/snoyberg/http-client/issues/304)
+
 ## 0.5.12.1
 
 * Make the chunked transfer-encoding detection case insensitive

--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -136,11 +136,11 @@ module Network.HTTP.Client
     , requestFromURI
     , requestFromURI_
     , defaultRequest
-
     , applyBasicAuth
     , urlEncodedBody
     , getUri
     , setRequestIgnoreStatus
+    , setRequestCheckStatus
     , setQueryString
 #if MIN_VERSION_http_types(0,12,1)
     , setQueryStringPartialEscape
@@ -178,6 +178,7 @@ module Network.HTTP.Client
     , responseHeaders
     , responseBody
     , responseCookieJar
+    , throwErrorStatusCodes
       -- ** Response body
     , BodyReader
     , brRead

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -1,5 +1,5 @@
 name:                http-client
-version:             0.5.12.1
+version:             0.5.13
 synopsis:            An HTTP client engine
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client

--- a/http-conduit/ChangeLog.md
+++ b/http-conduit/ChangeLog.md
@@ -1,3 +1,9 @@
+## 2.3.2
+
+* Adds `parseRequestThrow`, `parseRequestThrow_`, and
+  `setRequestCheckStatus` to `Network.HTTP.Simple`.
+  See [#304](https://github.com/snoyberg/http-client/issues/304)
+
 ## 2.3.1
 
 * Reexport Query from Network.HTTP.Types


### PR DESCRIPTION
I re-encountered the issue described in #304 , so figured it was definitely time to address this in the library.

Not sure about only exporting `parseRequestThrow` / `parseRequestThrow_` from the simple API.  Also might make sense to re-export `throwErrorStatusCodes`