### PR TITLE
Add a public function to use `Connection` by the user.

### DIFF
--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -1,3 +1,8 @@
+## 0.5.14
+
+* Add `withConnection` function.  
+  See [#352](https://github.com/snoyberg/http-client/pull/352).
+
 ## 0.5.13
 
 * Adds `setRequestCheckStatus` and `throwErrorStatusCodes` functions.

--- a/http-client/Data/KeyedPool.hs
+++ b/http-client/Data/KeyedPool.hs
@@ -33,6 +33,7 @@ module Data.KeyedPool
     , managedResource
     , managedReused
     , managedRelease
+    , keepAlive
     , Reuse (..)
     , dummyManaged
     ) where
@@ -45,7 +46,7 @@ import Data.Map (Map)
 import Data.Maybe (isJust)
 import qualified Data.Map.Strict as Map
 import Data.Time (UTCTime, getCurrentTime, addUTCTime)
-import Data.IORef (IORef, newIORef, mkWeakIORef)
+import Data.IORef (IORef, newIORef, mkWeakIORef, readIORef)
 import qualified Data.Foldable as F
 import GHC.Conc (unsafeIOToSTM)
 import System.IO.Unsafe (unsafePerformIO)
@@ -318,3 +319,7 @@ dummyManaged resource = Managed
 
 ignoreExceptions :: IO () -> IO ()
 ignoreExceptions f = f `catch` \(_ :: SomeException) -> return ()
+
+-- | Prevent the managed resource from getting released before you want to use.
+keepAlive :: Managed resource -> IO ()
+keepAlive = readIORef . _managedAlive

--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -193,6 +193,7 @@ module Network.HTTP.Client
     , Cookie (..)
     , CookieJar
     , Proxy (..)
+    , withProxiedConnection
       -- * Cookies
     , module Network.HTTP.Client.Cookies
     ) where

--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -193,7 +193,7 @@ module Network.HTTP.Client
     , Cookie (..)
     , CookieJar
     , Proxy (..)
-    , withProxiedConnection
+    , withConnection
       -- * Cookies
     , module Network.HTTP.Client.Cookies
     ) where

--- a/http-client/Network/HTTP/Client/Core.hs
+++ b/http-client/Network/HTTP/Client/Core.hs
@@ -11,7 +11,7 @@ module Network.HTTP.Client.Core
     , responseClose
     , httpRedirect
     , httpRedirect'
-    , withProxiedConnection
+    , withConnection
     ) where
 
 import Network.HTTP.Types
@@ -278,8 +278,8 @@ responseClose = runResponseClose . responseClose'
 -- through the connection (e.g. connection by the WebSocket protocol).
 --
 -- @since 0.5.14
-withProxiedConnection :: Request -> Manager -> (Connection -> IO a) -> IO a
-withProxiedConnection origReq man action = do
+withConnection :: Request -> Manager -> (Connection -> IO a) -> IO a
+withConnection origReq man action = do
     mHttpConn <- getConn (mSetProxy man origReq) man
     action (managedResource mHttpConn) <* keepAlive mHttpConn
         `finally` managedRelease mHttpConn DontReuse

--- a/http-client/Network/HTTP/Client/Core.hs
+++ b/http-client/Network/HTTP/Client/Core.hs
@@ -11,6 +11,7 @@ module Network.HTTP.Client.Core
     , responseClose
     , httpRedirect
     , httpRedirect'
+    , withProxiedConnection
     ) where
 
 import Network.HTTP.Types
@@ -270,3 +271,11 @@ httpRedirect' count0 http' req0 = go count0 req0 []
 -- Since 0.1.0
 responseClose :: Response a -> IO ()
 responseClose = runResponseClose . responseClose'
+
+-- | Perform an action using a @Connection@ acquired from the given @Manager@,
+--   considering the proxy server.
+withProxiedConnection :: Request -> Manager -> (Connection -> IO a) -> IO a
+withProxiedConnection origReq man action = do
+    mHttpConn <- getConn (mSetProxy man origReq) man
+    action (managedResource mHttpConn) <* keepAlive mHttpConn
+        `finally` managedRelease mHttpConn DontReuse

--- a/http-client/Network/HTTP/Client/Core.hs
+++ b/http-client/Network/HTTP/Client/Core.hs
@@ -272,8 +272,12 @@ httpRedirect' count0 http' req0 = go count0 req0 []
 responseClose :: Response a -> IO ()
 responseClose = runResponseClose . responseClose'
 
--- | Perform an action using a @Connection@ acquired from the given @Manager@,
---   considering the proxy server.
+-- | Perform an action using a @Connection@ acquired from the given @Manager@.
+--
+-- You should use this only when you have to read and write interactively
+-- through the connection (e.g. connection by the WebSocket protocol).
+--
+-- @since 0.5.14
 withProxiedConnection :: Request -> Manager -> (Connection -> IO a) -> IO a
 withProxiedConnection origReq man action = do
     mHttpConn <- getConn (mSetProxy man origReq) man

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -1,5 +1,5 @@
 name:                http-client
-version:             0.5.13
+version:             0.5.14
 synopsis:            An HTTP client engine
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client


### PR DESCRIPTION
I'm trying to create a websocket client library supporting websocket
connection via an HTTP proxy server.

To implement the complex features such as referring `http_proxy` environment
variable, I want to combine the http-client package with the websockets package
to reuse http-client's features related to proxy, TLS and so on.

The `withProxiedConnection` function enables that by providing a `Connection`
object configured for `http_proxy` and TLS to the library user while closing
the connection safely.

(Update) Note:

- Here's a sample code to connect by WebSocket with the `withProxiedConnection`: https://github.com/snoyberg/http-client/blob/926542559f46cfffd372d530f464d2dadf2a2033/http-client-tls/sample/sample.hs
- Related reddit thread: https://www.reddit.com/r/haskell/comments/8nh6ud/preventing_an_object_from_getting_gced_and/