### PR TITLE
Add requestMaxAttempts feature

### DIFF
--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -163,6 +163,7 @@ module Network.HTTP.Client
     , responseTimeout
     , cookieJar
     , requestVersion
+    , requestMaxAttempts
       -- ** Request body
     , RequestBody (..)
     , Popper

--- a/http-client/Network/HTTP/Client/Core.hs
+++ b/http-client/Network/HTTP/Client/Core.hs
@@ -125,12 +125,7 @@ httpRaw' req0 m = do
     case ex0 of
         Left se | attemptsRemaining req0 && mRetryableException m se ->
             httpRaw' (decrementMaxAttempts req0) m
-        Left se -> do
-            case fromException se of
-                Just (hecw :: HttpExceptionContentWrapper) ->
-                    throwHttp . MaxAttempts . unHttpExceptionContentWrapper $ hecw
-                Nothing ->
-                    throwHttp . MaxAttempts . InternalException $ se
+        Left se -> throwIO se
         Right r -> return r
 
   where

--- a/http-client/Network/HTTP/Client/Core.hs
+++ b/http-client/Network/HTTP/Client/Core.hs
@@ -136,7 +136,7 @@ httpRaw' req0 m = do
   where
     decrementMaxAttempts :: Request -> Request
     decrementMaxAttempts req =
-        req { requestMaxAttempts = flip (-) 1 <$> requestMaxAttempts req }
+        req { requestMaxAttempts = subtract 1 <$> requestMaxAttempts req }
 
     attemptsRemaining req =
         case requestMaxAttempts req of

--- a/http-client/Network/HTTP/Client/Core.hs
+++ b/http-client/Network/HTTP/Client/Core.hs
@@ -14,6 +14,7 @@ module Network.HTTP.Client.Core
     , withConnection
     ) where
 
+import Control.Monad (when)
 import Network.HTTP.Types
 import Network.HTTP.Client.Manager
 import Network.HTTP.Client.Types
@@ -85,41 +86,63 @@ httpRaw'
      -> Manager
      -> IO (Request, Response BodyReader)
 httpRaw' req0 m = do
-    let req' = mSetProxy m req0
-    (req, cookie_jar') <- case cookieJar req' of
-        Just cj -> do
-            now <- getCurrentTime
-            return $ insertCookiesIntoRequest req' (evictExpiredCookies cj now) now
-        Nothing -> return (req', Data.Monoid.mempty)
-    (timeout', mconn) <- getConnectionWrapper
-        (responseTimeout' req)
-        (getConn req m)
+    ex0 <- try $ do
+        let req' = mSetProxy m req0
+        (req, cookie_jar') <- case cookieJar req' of
+            Just cj -> do
+                now <- getCurrentTime
+                return $ insertCookiesIntoRequest req' (evictExpiredCookies cj now) now
+            Nothing -> return (req', Data.Monoid.mempty)
 
-    -- Originally, we would only test for exceptions when sending the request,
-    -- not on calling @getResponse@. However, some servers seem to close
-    -- connections after accepting the request headers, so we need to check for
-    -- exceptions in both.
-    ex <- try $ do
-        cont <- requestBuilder (dropProxyAuthSecure req) (managedResource mconn)
+        (timeout', mconn) <- getConnectionWrapper
+            (responseTimeout' req)
+            (getConn req m)
 
-        getResponse timeout' req mconn cont
+        -- Originally, we would only test for exceptions when sending the request,
+        -- not on calling @getResponse@. However, some servers seem to close
+        -- connections after accepting the request headers, so we need to check for
+        -- exceptions in both.
+        ex <- try $ do
+            cont <- requestBuilder (dropProxyAuthSecure req) (managedResource mconn)
 
-    case ex of
-        -- Connection was reused, and might have been closed. Try again
-        Left e | managedReused mconn && mRetryableException m e -> do
-            managedRelease mconn DontReuse
-            httpRaw' req m
-        -- Not reused, or a non-retry, so this is a real exception
-        Left e -> throwIO e
-        -- Everything went ok, so the connection is good. If any exceptions get
-        -- thrown in the response body, just throw them as normal.
-        Right res -> case cookieJar req' of
-            Just _ -> do
-                now' <- getCurrentTime
-                let (cookie_jar, _) = updateCookieJar res req now' cookie_jar'
-                return (req, res {responseCookieJar = cookie_jar})
-            Nothing -> return (req, res)
+            getResponse timeout' req mconn cont
+
+        case ex of
+            -- Connection was reused, and might have been closed. Try again
+            Left (e :: SomeException) -> do
+                when (managedReused mconn) $
+                    managedRelease mconn DontReuse
+                throwIO e
+            -- Everything went ok, so the connection is good. If any exceptions get
+            -- thrown in the response body, just throw them as normal.
+            Right res -> case cookieJar req' of
+                Just _ -> do
+                    now' <- getCurrentTime
+                    let (cookie_jar, _) = updateCookieJar res req now' cookie_jar'
+                    return (req, res {responseCookieJar = cookie_jar})
+                Nothing -> return (req, res)
+
+    case ex0 of
+        Left se | attemptsRemaining req0 && mRetryableException m se ->
+            httpRaw' (decrementMaxAttempts req0) m
+        Left se -> do
+            case fromException se of
+                Just (hecw :: HttpExceptionContentWrapper) ->
+                    throwHttp . MaxAttempts . unHttpExceptionContentWrapper $ hecw
+                Nothing ->
+                    throwHttp . MaxAttempts . InternalException $ se
+        Right r -> return r
+
   where
+    decrementMaxAttempts :: Request -> Request
+    decrementMaxAttempts req =
+        req { requestMaxAttempts = flip (-) 1 <$> requestMaxAttempts req }
+
+    attemptsRemaining req =
+        case requestMaxAttempts req of
+            Nothing -> True
+            Just a  -> a > 1
+
     getConnectionWrapper mtimeout f =
         case mtimeout of
             Nothing -> fmap ((,) Nothing) f

--- a/http-client/Network/HTTP/Client/Request.hs
+++ b/http-client/Network/HTTP/Client/Request.hs
@@ -287,6 +287,7 @@ defaultRequest = Request
                 Just (_ :: IOException) -> return ()
                 Nothing -> throwIO se
         , requestManagerOverride = Nothing
+        , requestMaxAttempts = Just 1
         }
 
 -- | Parses a URL via 'parseRequest_'

--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -9,6 +9,7 @@ module Network.HTTP.Client.Types
     , StatusHeaders (..)
     , HttpException (..)
     , HttpExceptionContent (..)
+    , HttpExceptionContentWrapper
     , unHttpExceptionContentWrapper
     , throwHttp
     , toHttpException
@@ -232,6 +233,9 @@ data HttpExceptionContent
                    | InvalidProxySettings Text
                    -- ^ Proxy settings are not valid (Windows specific currently)
                    -- @since 0.5.7
+
+                   | MaxAttempts HttpExceptionContent
+                   -- ^ The maximum number of attempts has been reached.
     deriving (Show, T.Typeable)
 
 -- Purposely not providing this instance, since we don't want users to
@@ -547,6 +551,18 @@ data Request = Request
     -- dealing with implicit global managers, such as in @Network.HTTP.Simple@
     --
     -- @since 0.4.28
+
+    , requestMaxAttempts :: Maybe Int
+    -- ^ The 'Request' will be retried if all the following conditions are met:
+    --
+    -- * this value is greater than 1 or @Nothing@,
+    -- * the exception is retryable as defined by 'managerRetryableException'.
+    --
+    -- Note: Exceptions thrown via 'checkResponse' will not trigger a retry.
+    --
+    -- Default: Just 1
+    --
+    -- @since
     }
     deriving T.Typeable
 
@@ -575,6 +591,7 @@ instance Show Request where
         , "  redirectCount        = " ++ show (redirectCount x)
         , "  responseTimeout      = " ++ show (responseTimeout x)
         , "  requestVersion       = " ++ show (requestVersion x)
+        , "  maxAttempts          = " ++ show (requestMaxAttempts x)
         , "}"
         ]
 

--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -233,9 +233,6 @@ data HttpExceptionContent
                    | InvalidProxySettings Text
                    -- ^ Proxy settings are not valid (Windows specific currently)
                    -- @since 0.5.7
-
-                   | MaxAttempts HttpExceptionContent
-                   -- ^ The maximum number of attempts has been reached.
     deriving (Show, T.Typeable)
 
 -- Purposely not providing this instance, since we don't want users to

--- a/http-conduit/test/main.hs
+++ b/http-conduit/test/main.hs
@@ -8,7 +8,7 @@ import qualified Data.ByteString.Lazy.Char8 as L8
 import Test.HUnit
 import Network.Wai hiding (requestBody)
 import Network.Wai.Conduit (responseSource, sourceRequestBody)
-import Network.HTTP.Client (streamFile)
+import Network.HTTP.Client (streamFile, requestMaxAttempts)
 import System.IO.Temp (withSystemTempFile)
 import qualified Network.Wai as Wai
 import Network.Wai.Handler.Warp (runSettings, defaultSettings, setPort, setBeforeMainLoop, Settings, setTimeout)
@@ -435,10 +435,11 @@ main = do
     it "reuse/connection close tries again" $ do
         withAppSettings (setTimeout 1) (const app) $ \port -> do
             req <- parseUrlThrow $ "http://localhost:" ++ show port
+            let req' = req { requestMaxAttempts = Just 2 }
             man <- newManager tlsManagerSettings
-            res1 <- httpLbs req man
+            res1 <- httpLbs req' man
             threadDelay 3000000
-            res2 <- httpLbs req man
+            res2 <- httpLbs req' man
             let f res = res
                     { NHC.responseHeaders = filter (not . isDate) (NHC.responseHeaders res)
                     }


### PR DESCRIPTION
This value dictates how many attempts will be made to process a Request.
A retry will only occur if managerRetryableException retruns True.
A value of Nothing represents an infinite number of retries.