### PR TITLE
Support SNI in http-client-openssl

### DIFF
--- a/http-client-openssl/ChangeLog.md
+++ b/http-client-openssl/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.2.2.0
+
+* Tell OpenSSL what host is being contacted, so it can use the SNI extension for certificate selection if the server requires it.
+
 ## 0.2.1.1
 
 * Fix a connection-bug with http-proxy(Previous version closes a connection before reading all respose-data.)

--- a/http-client-openssl/Network/HTTP/Client/OpenSSL.hs
+++ b/http-client-openssl/Network/HTTP/Client/OpenSSL.hs
@@ -38,6 +38,7 @@ opensslManagerSettings mkContext = defaultManagerSettings
                 $ \sock -> do
                     N.connect sock address
                     ssl <- SSL.connection ctx sock
+                    SSL.setTlsextHostName ssl host'
                     SSL.connect ssl
                     makeConnection
                         (SSL.read ssl 32752)
@@ -69,6 +70,7 @@ opensslManagerSettings mkContext = defaultManagerSettings
                     connectionWrite conn connstr
                     checkConn conn
                     ssl <- SSL.connection ctx sock
+                    SSL.setTlsextHostName ssl host'
                     SSL.connect ssl
                     makeConnection
                         (SSL.read ssl 32752)

--- a/http-client-openssl/http-client-openssl.cabal
+++ b/http-client-openssl/http-client-openssl.cabal
@@ -1,5 +1,5 @@
 name:                http-client-openssl
-version:             0.2.1.1
+version:             0.2.2.0
 synopsis:            http-client backend using the OpenSSL library.
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client


### PR DESCRIPTION
Tell OpenSSL what the host name is before making the connection.

I haven't tried the proxy branch; I don't have an HTTPS proxy to test with.  But it seems likely to be correct, judging from the code.
