### PR TITLE
Wrap HsOpenSSL exceptions into http-client exceptions

### DIFF
--- a/http-client-openssl/ChangeLog.md
+++ b/http-client-openssl/ChangeLog.md
@@ -1,3 +1,8 @@
+## 0.3.0.0
+
+* Wrap HsOpenSSL specific exceptions into http-clients own `HttpExceptionRequest`. This is a breaking change and might need adjustment with respect to exception handling in user code.
+* More robust handling of unexpectedly closed connections
+
 ## 0.2.2.0
 
 * Tell OpenSSL what host is being contacted, so it can use the SNI extension for certificate selection if the server requires it.

--- a/http-client-openssl/Network/HTTP/Client/OpenSSL.hs
+++ b/http-client-openssl/Network/HTTP/Client/OpenSSL.hs
@@ -11,6 +11,7 @@ import Network.HTTP.Client.Internal
 import Control.Exception
 import Network.Socket.ByteString (sendAll, recv)
 import OpenSSL
+import qualified Data.ByteString as S
 import qualified Network.Socket as N
 import qualified OpenSSL.Session       as SSL
 
@@ -42,7 +43,7 @@ opensslManagerSettings mkContext = defaultManagerSettings
                     SSL.setTlsextHostName ssl host'
                     SSL.connect ssl
                     makeConnection
-                        (SSL.read ssl 32752)
+                        (SSL.read ssl 32752 `catch` \(_ :: SSL.ConnectionAbruptlyTerminated) -> pure S.empty)
                         (SSL.write ssl)
                         (N.close sock)
     , managerTlsProxyConnection = do
@@ -74,7 +75,7 @@ opensslManagerSettings mkContext = defaultManagerSettings
                     SSL.setTlsextHostName ssl host'
                     SSL.connect ssl
                     makeConnection
-                        (SSL.read ssl 32752)
+                        (SSL.read ssl 32752 `catch` \(_ :: SSL.ConnectionAbruptlyTerminated) -> pure S.empty)
                         (SSL.write ssl)
                         (N.close sock)
 

--- a/http-client-openssl/http-client-openssl.cabal
+++ b/http-client-openssl/http-client-openssl.cabal
@@ -1,5 +1,5 @@
 name:                http-client-openssl
-version:             0.2.2.0
+version:             0.3.0.0
 synopsis:            http-client backend using the OpenSSL library.
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client

--- a/http-client-openssl/http-client-openssl.cabal
+++ b/http-client-openssl/http-client-openssl.cabal
@@ -20,6 +20,7 @@ library
   exposed-modules:     Network.HTTP.Client.OpenSSL
   other-extensions:    ScopedTypeVariables
   build-depends:       base >= 4 && < 5
+                     , bytestring
                      , http-client >= 0.2
                      , network
                      , HsOpenSSL


### PR DESCRIPTION
This wraps exceptions from HsOpenSSL in a similar way to the TLS based backend. Helps streamlining exception handling a lot. Also it fixes an issue with connection reuse in the face of early termination.

This is probably a breaking change as it changes the exceptions being thrown.