### PR TITLE
Reestablish completeness check for unlimited body reader

### DIFF
--- a/http-client/Network/HTTP/Client/Body.hs
+++ b/http-client/Network/HTTP/Client/Body.hs
@@ -115,9 +115,13 @@ makeUnlimitedReader :: Connection -> IO BodyReader
 makeUnlimitedReader Connection {..} = do
     icomplete <- newIORef False
     return $ do
-        bs <- connectionRead
-        when (S.null bs) $ writeIORef icomplete True
-        return bs
+      complete <- readIORef icomplete
+      if complete
+          then return empty
+          else do
+              bs <- connectionRead
+              when (S.null bs) $ writeIORef icomplete True
+              return bs
 
 makeLengthReader :: Int -> Connection -> IO BodyReader
 makeLengthReader count0 Connection {..} = do

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -1,5 +1,5 @@
 name:                http-client
-version:             0.5.13.1
+version:             0.5.13.2
 synopsis:            An HTTP client engine
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client


### PR DESCRIPTION
This must have gone missing at some point.