### PR TITLE
Reexport RequestHeaders

### DIFF
--- a/http-conduit/ChangeLog.md
+++ b/http-conduit/ChangeLog.md
@@ -1,6 +1,11 @@
+## 2.3.4
+
+* Reexport RequestHeaders from Network.HTTP.Types (what was intended in last version)
+* Fix mistake in ChangeLog
+
 ## 2.3.3
 
-* Reexport Header, QueryItem and RequestHeaders from Network.HTTP.Types
+* Reexport Header, QueryItem and ResponseHeaders from Network.HTTP.Types
 * Rewrite a type signature of setRequestHeaders with RequestHeaders
 
 ## 2.3.2

--- a/http-conduit/Network/HTTP/Simple.hs
+++ b/http-conduit/Network/HTTP/Simple.hs
@@ -32,8 +32,9 @@ module Network.HTTP.Simple
     , H.Query
     , H.QueryItem
     , H.Request
-    , H.ResponseHeaders
+    , H.RequestHeaders
     , H.Response
+    , H.ResponseHeaders
     , JSONException (..)
     , H.HttpException (..)
     , H.Proxy (..)

--- a/http-conduit/http-conduit.cabal
+++ b/http-conduit/http-conduit.cabal
@@ -1,5 +1,5 @@
 name:            http-conduit
-version:         2.3.3
+version:         2.3.4
 license:         BSD3
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
I've accidentally reexported ResponseHeaders instead of RequestHeaders. This PR fixes it (and make it a feature, not a bug).