### PR TITLE
Allow renderParts to be used in pure code

### DIFF
--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for http-client
 
+## 0.6.0
+
+* Generalize `renderParts` over arbitrary applicative functors.  One particular
+  use case that is enabled by this change is that now `renderParts` can be used
+  in pure code by using it in combination with `runIdentity`.
+
 ## 0.5.14
 
 * Omit port for `getUri` when protocol is `http` and port is `80`, or when

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -1,5 +1,5 @@
 name:                http-client
-version:             0.5.14
+version:             0.6.0
 synopsis:            An HTTP client engine
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client

--- a/http-conduit/http-conduit.cabal
+++ b/http-conduit/http-conduit.cabal
@@ -29,7 +29,7 @@ library
                  , conduit               >= 1.2
                  , conduit-extra         >= 1.1
                  , http-types            >= 0.7
-                 , http-client           >= 0.5.13  && < 0.6
+                 , http-client           >= 0.5.13  && < 0.7
                  , http-client-tls       >= 0.3     && < 0.4
                  , mtl
                  , unliftio-core


### PR DESCRIPTION
I want to use `Network.HTTP.Client.MultipartFormData.renderParts` in pure code.  So what I did is generalize `renderParts` over arbitrary applicative functors.  This allows me to use it with `runIdentity`.

@snoyberg please feel free to bikeshed, anything that enables my use case works for me.