### PR TITLE
Fix shouldStripHeaderOnRedirect export for backwards compat

### DIFF
--- a/http-conduit/Network/HTTP/Conduit.hs
+++ b/http-conduit/Network/HTTP/Conduit.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE FlexibleContexts  #-}
 {-# LANGUAGE OverloadedStrings #-}
 -- |
@@ -158,7 +159,9 @@ module Network.HTTP.Conduit
     , rawBody
     , decompress
     , redirectCount
+#if MIN_VERSION_http_client(0,6,2)
     , shouldStripHeaderOnRedirect
+#endif
     , checkResponse
     , responseTimeout
     , cookieJar


### PR DESCRIPTION
Fixes #391 

Alternative to #392 

However, compared to #392 this will require a new release. I don't mind either way.