### PR TITLE
don't fail on a single malformed header from the server

### DIFF
--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -1,5 +1,11 @@
 # Changelog for http-client
 
+## 0.6.4
+
+* Avoid throwing an exception when a malformed HTTP header is received,
+  to be as robust as commonly used HTTP clients.
+  See [#398](https://github.com/snoyberg/http-client/issues/398)
+
 ## 0.6.3
 
 * Detect response body termination before reading an extra null chunk

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -1,5 +1,5 @@
 name:                http-client
-version:             0.6.3
+version:             0.6.4
 synopsis:            An HTTP client engine
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client


### PR DESCRIPTION
A line in the HTTP response that lacks a ':' caused an exception,
but other commonly used http implementations (curl, wget, firefox)
are robust in what they accept here. So a web server that is
misconfigured with eg, a '\n' in the middle of a header value,
would seem to work ok but break when http-client is used.
Fixed by ignoring such bogus and unparseable lines.

The InvalidHeader constructor is no longer used in http-client, so could
be later removed; it has been left in to avoid this bug fix getting
entangled with an API bump.

Fixes https://github.com/snoyberg/http-client/issues/398