### PR TITLE
Responses with a status code that signals "no content" are not handled properly through an SSL proxy

### DIFF
--- a/http-client/Network/HTTP/Client/Response.hs
+++ b/http-client/Network/HTTP/Client/Response.hs
@@ -102,7 +102,7 @@ getResponse timeout' req@(Request {..}) mconn cont = do
         -- RFC 2616 section 4.4_1 defines responses that must not include a body
         if hasNoBody method (W.statusCode s) || (mcl == Just 0 && not isChunked)
             then do
-                cleanup False -- The body hasn't actually been consumed
+                cleanup True
                 return brEmpty
             else do
                 body1 <-

--- a/http-client/Network/HTTP/Client/Response.hs
+++ b/http-client/Network/HTTP/Client/Response.hs
@@ -102,7 +102,7 @@ getResponse timeout' req@(Request {..}) mconn cont = do
         -- RFC 2616 section 4.4_1 defines responses that must not include a body
         if hasNoBody method (W.statusCode s) || (mcl == Just 0 && not isChunked)
             then do
-                cleanup True
+                cleanup False -- The body hasn't actually been consumed
                 return brEmpty
             else do
                 body1 <-


### PR DESCRIPTION
To reproduce install a https proxy (tried with Hoverfly), set the `https_proxy` environment variable and  run the following script:
```haskell
#!/usr/bin/env stack
-- stack -v runghc --package connection --package http-client --package http-client-tls 
{-# LANGUAGE OverloadedStrings #-}

import Prelude

import Network.Connection
import Control.Monad (forM)
import Network.HTTP.Client
import Network.HTTP.Client.TLS


main :: IO ()
main = do

    let (Just req) = parseUrlThrow "https://assertible.com/blog"
    let managerSettingsTls =
          mkManagerSettings
            (TLSSettingsSimple True False False) -- Don't check certificate because proxy may mitm it
            Nothing
    man <- newManager $
      managerSetProxy (proxyEnvironment Nothing) $
      managerSettingsTls

    results <- forM [1..250] $ \_ -> do
        res <- httpLbs req{method="HEAD"} man
        pure (responseStatus res)

    print (length results)
```
The above script, when compiled with the `-threaded` RTS, will randomly fail with:
```
invalid-status-line: HttpExceptionRequest Request {
  host                 = "assertible.com"
  port                 = 443
  secure               = True
  requestHeaders       = []
  path                 = "/blog"
  queryString          = ""
  method               = "HEAD"
  proxy                = Nothing
  rawBody              = False
  redirectCount        = 10
  responseTimeout      = ResponseTimeoutDefault
  requestVersion       = HTTP/1.1
}
 (InvalidStatusLine "0")
```

This PR avoids the problem although it probably isn't the optimal solution as it forces keep-alive connections to be closed. Maybe consuming the (empty) response is a better fix.