### PR TITLE
Provide the direct link to the tutorial

### DIFF
--- a/http-client/README.md
+++ b/http-client/README.md
@@ -2,7 +2,7 @@ http-client
 ===========
 
 Full tutorial docs are available at:
-https://haskell-lang.org/library/http-client
+https://github.com/snoyberg/http-client/blob/master/TUTORIAL.md
 
 An HTTP client engine, intended as a base layer for more user-friendly packages.
 


### PR DESCRIPTION
Currently, the tutorial link points to an FPComplete page that points back to a link on GitHub.