### PR TITLE
Fix Win32-2.8 compat.

### DIFF
--- a/http-client/Network/HTTP/Proxy.hs
+++ b/http-client/Network/HTTP/Proxy.hs
@@ -175,7 +175,7 @@ registryProxyString = catch
     enable <- toBool . maybe 0 id A.<$> regQueryValueDWORD hkey "ProxyEnable"
     if enable
         then do
-#if MIN_VERSION_Win32(2, 6, 0)
+#if MIN_VERSION_Win32(2, 6, 0) && !MIN_VERSION_Win32(2, 8, 0)
             server <- regQueryValue hkey "ProxyServer"
             exceptions <- try $ regQueryValue hkey "ProxyOverride" :: IO (Either IOException String)
 #else


### PR DESCRIPTION
It appears as if the `regQueryValue` was fixed in the Win32-2.8 series: https://github.com/haskell/win32/commit/1c46705d72341ac608c58f29b61ceadcca7c7440