### PR TITLE
http-client-openssl: Set SNI hostname to serverName when using https_proxy

### DIFF
--- a/http-client-openssl/ChangeLog.md
+++ b/http-client-openssl/ChangeLog.md
@@ -1,3 +1,8 @@
+## 0.3.1.0
+* Fix a bug with http-proxy that would cause SNI to be set incorrectly; (would
+  use the domain of the proxy, instead of the server we're trying to reach
+  _through_ the proxy)
+
 ## 0.3.0.0
 
 * Wrap HsOpenSSL specific exceptions into http-clients own `HttpExceptionRequest`. This is a breaking change and might need adjustment with respect to exception handling in user code.

--- a/http-client-openssl/Network/HTTP/Client/OpenSSL.hs
+++ b/http-client-openssl/Network/HTTP/Client/OpenSSL.hs
@@ -48,7 +48,7 @@ opensslManagerSettings mkContext = defaultManagerSettings
                         (N.close sock)
     , managerTlsProxyConnection = do
         ctx <- mkContext
-        return $ \connstr checkConn _serverName _ha host' port' -> do
+        return $ \connstr checkConn serverName _ha host' port' -> do
             -- Copied/modified from openssl-streams
             let hints      = N.defaultHints
                                 { N.addrFlags      = [N.AI_ADDRCONFIG, N.AI_NUMERICSERV]
@@ -72,7 +72,7 @@ opensslManagerSettings mkContext = defaultManagerSettings
                     connectionWrite conn connstr
                     checkConn conn
                     ssl <- SSL.connection ctx sock
-                    SSL.setTlsextHostName ssl host'
+                    SSL.setTlsextHostName ssl serverName
                     SSL.connect ssl
                     makeConnection
                         (SSL.read ssl 32752 `catch` \(_ :: SSL.ConnectionAbruptlyTerminated) -> return S.empty)

--- a/http-client-openssl/http-client-openssl.cabal
+++ b/http-client-openssl/http-client-openssl.cabal
@@ -1,5 +1,5 @@
 name:                http-client-openssl
-version:             0.3.0.0
+version:             0.3.1.0
 synopsis:            http-client backend using the OpenSSL library.
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client


### PR DESCRIPTION
Setting it to `host'` here is wrong. that's the address of the `https_proxy`, not the server we're trying to make a request to.

Instead, it should be set to `serverName`.

Now the behaviour is the same as in `http-client-tls` which does not have this bug

Fixes https://github.com/wireapp/echo-bot/issues/45#issuecomment-625359416