### PR TITLE
http-conduit: Fix tests on big-endian systems

### DIFF
--- a/http-conduit/test/main.hs
+++ b/http-conduit/test/main.hs
@@ -406,7 +406,7 @@ main = do
     describe "hostAddress" $ do
         it "overrides host" $ withApp app $ \port -> do
             req' <- parseUrlThrow $ "http://example.com:" ++ show port
-            let req = req' { hostAddress = Just 0x0100007f } -- 127.0.0.1
+            let req = req' { hostAddress = Just $ NS.tupleToHostAddress (127, 0, 0, 1) }
             manager <- newManager tlsManagerSettings
             res <- httpLbs req manager
             responseBody res @?= "homepage for example.com"


### PR DESCRIPTION
Using the hard-coded `0x0100007f` value as `hostAddress` to represent
`127.0.0.1` does not work on big-endian systems. Use the
`tupleToHostAddress` function instead, which correctly computes the
hostAddress value.