### PR TITLE
Add support for TLS offload via proxy

### DIFF
--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for http-client
 
+## 0.7.2
+
+* Add a new proxy mode, proxySecureWithoutConnect, for sending HTTPS requests in plain text to a proxy without using the CONNECT method.
+
 ## 0.7.1
 
 * Remove `AI_ADDRCONFIG` [#400](https://github.com/snoyberg/http-client/issues/400)

--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -116,6 +116,7 @@ module Network.HTTP.Client
     , proxyFromRequest
     , noProxy
     , useProxy
+    , useProxySendRequestMode
     , proxyEnvironment
     , proxyEnvironmentNamed
     , defaultProxy

--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -116,7 +116,7 @@ module Network.HTTP.Client
     , proxyFromRequest
     , noProxy
     , useProxy
-    , useProxySendRequestMode
+    , useProxySecureWithoutConnect
     , proxyEnvironment
     , proxyEnvironmentNamed
     , defaultProxy

--- a/http-client/Network/HTTP/Client/Headers.hs
+++ b/http-client/Network/HTTP/Client/Headers.hs
@@ -12,9 +12,7 @@ import           Control.Monad
 import qualified Data.ByteString                as S
 import qualified Data.ByteString.Char8          as S8
 import qualified Data.CaseInsensitive           as CI
-import           Data.Char (ord)
 import           Data.Maybe (mapMaybe)
-import           Data.Monoid
 import           Network.HTTP.Client.Connection
 import           Network.HTTP.Client.Types
 import           System.Timeout                 (timeout)

--- a/http-client/Network/HTTP/Client/Headers.hs
+++ b/http-client/Network/HTTP/Client/Headers.hs
@@ -13,6 +13,7 @@ import qualified Data.ByteString                as S
 import qualified Data.ByteString.Char8          as S8
 import qualified Data.CaseInsensitive           as CI
 import           Data.Maybe (mapMaybe)
+import           Data.Monoid
 import           Network.HTTP.Client.Connection
 import           Network.HTTP.Client.Types
 import           System.Timeout                 (timeout)

--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -17,6 +17,7 @@ module Network.HTTP.Client.Manager
     , proxyEnvironmentNamed
     , defaultProxy
     , dropProxyAuthSecure
+    , useProxySendRequestMode
     ) where
 
 import qualified Data.ByteString.Char8 as S8
@@ -216,7 +217,7 @@ connKey req =
             | secure req -> simple CKSecure
             | otherwise -> simple CKRaw
         Just p
-            | secure req -> CKProxy
+            | secure req && proxySecureMode req == ProxySecureConnect -> CKProxy
                 (proxyHost p)
                 (proxyPort p)
                 (lookup "Proxy-Authorization" (requestHeaders req))
@@ -285,6 +286,16 @@ noProxy = ProxyOverride $ const $ return $ \req -> req { proxy = Nothing }
 -- Since 0.4.7
 useProxy :: Proxy -> ProxyOverride
 useProxy p = ProxyOverride $ const $ return $ \req -> req { proxy = Just p }
+
+-- | Send secure requests to the proxy in plain text rather than using CONNECT,
+-- regardless of the value in the @Request@.
+--
+-- Since 0.7.2
+useProxySendRequestMode :: ProxyOverride -> ProxyOverride
+useProxySendRequestMode (ProxyOverride existingOverride) = ProxyOverride $
+  \secure -> do
+    f <- existingOverride secure
+    return $ f . (\req -> req { proxySecureMode = ProxySecureSendRequest })
 
 -- | Get the proxy settings from the default environment variable (@http_proxy@
 -- for insecure, @https_proxy@ for secure). If no variable is set, then fall

--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -17,7 +17,7 @@ module Network.HTTP.Client.Manager
     , proxyEnvironmentNamed
     , defaultProxy
     , dropProxyAuthSecure
-    , useProxySendRequestMode
+    , useProxySecureWithoutConnect
     ) where
 
 import qualified Data.ByteString.Char8 as S8
@@ -211,21 +211,23 @@ getConn req m
     connkey = connKey req
 
 connKey :: Request -> ConnKey
-connKey req =
-    case proxy req of
-        Nothing
-            | secure req -> simple CKSecure
-            | otherwise -> simple CKRaw
-        Just p
-            | secure req && proxySecureMode req == ProxySecureConnect -> CKProxy
-                (proxyHost p)
-                (proxyPort p)
-                (lookup "Proxy-Authorization" (requestHeaders req))
-                (host req)
-                (port req)
-            | otherwise -> CKRaw Nothing (proxyHost p) (proxyPort p)
-  where
-    simple con = con (hostAddress req) (host req) (port req)
+connKey req@Request { proxy = Nothing, secure = False } =
+  CKRaw (hostAddress req) (host req) (port req)
+connKey req@Request { proxy = Nothing, secure = True  } =
+  CKSecure (hostAddress req) (host req) (port req)
+connKey Request { proxy = Just p, secure = False } =
+  CKRaw Nothing (proxyHost p) (proxyPort p)
+connKey req@Request { proxy = Just p, secure = True,
+                      proxySecureMode = ProxySecureWithConnect  } =
+  CKProxy
+    (proxyHost p)
+    (proxyPort p)
+    (lookup "Proxy-Authorization" (requestHeaders req))
+    (host req)
+    (port req)
+connKey Request { proxy = Just p, secure = True,
+                  proxySecureMode = ProxySecureWithoutConnect  } =
+  CKRaw Nothing (proxyHost p) (proxyPort p)
 
 mkCreateConnection :: ManagerSettings -> IO (ConnKey -> IO Connection)
 mkCreateConnection ms = do
@@ -290,12 +292,11 @@ useProxy p = ProxyOverride $ const $ return $ \req -> req { proxy = Just p }
 -- | Send secure requests to the proxy in plain text rather than using CONNECT,
 -- regardless of the value in the @Request@.
 --
--- Since 0.7.2
-useProxySendRequestMode :: ProxyOverride -> ProxyOverride
-useProxySendRequestMode (ProxyOverride existingOverride) = ProxyOverride $
-  \secure -> do
-    f <- existingOverride secure
-    return $ f . (\req -> req { proxySecureMode = ProxySecureSendRequest })
+-- @since 0.7.2
+useProxySecureWithoutConnect :: Proxy -> ProxyOverride
+useProxySecureWithoutConnect p = ProxyOverride $
+  const $ return $ \req -> req { proxy = Just p,
+                                 proxySecureMode = ProxySecureWithConnect }
 
 -- | Get the proxy settings from the default environment variable (@http_proxy@
 -- for insecure, @https_proxy@ for secure). If no variable is set, then fall

--- a/http-client/Network/HTTP/Client/Request.hs
+++ b/http-client/Network/HTTP/Client/Request.hs
@@ -36,7 +36,7 @@ module Network.HTTP.Client.Request
     , observedStreamFile
     , extractBasicAuthInfo
     , throwErrorStatusCodes
-    , addProxyPlainTextNoCONNECTMode
+    , addProxySecureWithoutConnect
     ) where
 
 import Data.Int (Int64)
@@ -356,8 +356,8 @@ addProxy hst prt req =
 -- | Send secure requests to the proxy in plain text rather than using CONNECT.
 --
 -- @since 0.7.2
-addProxyPlainTextNoCONNECTMode :: Request -> Request
-addProxyPlainTextNoCONNECTMode req = req { proxySecureMode = ProxySecureWithoutConnect }
+addProxySecureWithoutConnect :: Request -> Request
+addProxySecureWithoutConnect req = req { proxySecureMode = ProxySecureWithoutConnect }
 
 -- | Add a Proxy-Authorization header (with the specified username and
 -- password) to the given 'Request'. Ignore error handling:

--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -349,9 +349,9 @@ data Proxy = Proxy
 
 -- | Define how to make secure connections using a proxy server.
 data ProxySecureMode =
-  ProxySecureConnect
+  ProxySecureWithConnect
   -- ^ Use the HTTP CONNECT verb to forward a secure connection through the proxy.
-  | ProxySecureSendRequest
+  | ProxySecureWithoutConnect
   -- ^ Send the request directly to the proxy with an https URL. This mode can be
   -- used to offload TLS handling to a trusted local proxy.
   deriving (Show, Read, Eq, Ord, T.Typeable)

--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -37,6 +37,7 @@ module Network.HTTP.Client.Types
     , ProxyOverride (..)
     , StreamFileStatus (..)
     , ResponseTimeout (..)
+    , ProxySecureMode (..)
     ) where
 
 import qualified Data.Typeable as T (Typeable)
@@ -346,6 +347,15 @@ data Proxy = Proxy
     }
     deriving (Show, Read, Eq, Ord, T.Typeable)
 
+-- | Define how to make secure connections using a proxy server.
+data ProxySecureMode =
+  ProxySecureConnect
+  -- ^ Use the HTTP CONNECT verb to forward a secure connection through the proxy.
+  | ProxySecureSendRequest
+  -- ^ Send the request directly to the proxy with an https URL. This mode can be
+  -- used to offload TLS handling to a trusted local proxy.
+  deriving (Show, Read, Eq, Ord, T.Typeable)
+
 -- | When using one of the 'RequestBodyStream' \/ 'RequestBodyStreamChunked'
 -- constructors, you must ensure that the 'GivesPopper' can be called multiple
 -- times.  Usually this is not a problem.
@@ -600,6 +610,13 @@ data Request = Request
     -- when following a redirect. Default: keep all headers intact.
     --
     -- @since 0.6.2
+
+    , proxySecureMode :: ProxySecureMode
+    -- ^ How to proxy an HTTPS request.
+    --
+    -- Default: Use HTTP CONNECT.
+    --
+    -- @since 0.7.2
     }
     deriving T.Typeable
 
@@ -633,6 +650,7 @@ instance Show Request where
         , "  redirectCount        = " ++ show (redirectCount x)
         , "  responseTimeout      = " ++ show (responseTimeout x)
         , "  requestVersion       = " ++ show (requestVersion x)
+        , "  proxySecureMode      = " ++ show (proxySecureMode x)
         , "}"
         ]
 

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -1,5 +1,5 @@
 name:                http-client
-version:             0.7.1
+version:             0.7.2
 synopsis:            An HTTP client engine
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client


### PR DESCRIPTION
For server applications that make outbound HTTP requests as a client, it is often preferrable to use a local forward proxy for caching and TLS offload.

For this use case, it makes more sense to send the request directly to the proxy in plain text, with an `https://` URL, so that the proxy can cache the response without needing to be configured to generate self-signed certificates to intercept requests through CONNECT.

This PR adds a new non-default setting to use this mode of connecting to proxies.