### PR TITLE
http-client-openssl: use hostAddress from Request

### DIFF
--- a/http-client-openssl/ChangeLog.md
+++ b/http-client-openssl/ChangeLog.md
@@ -1,3 +1,7 @@
+## 0.3.3
+
+* Use `hostAddress` from `Request`.
+
 ## 0.3.2.0
 
 * http-client-openssl: added reasonable OpenSSL default settings

--- a/http-client-openssl/http-client-openssl.cabal
+++ b/http-client-openssl/http-client-openssl.cabal
@@ -1,5 +1,5 @@
 name:                http-client-openssl
-version:             0.3.2.0
+version:             0.3.3
 synopsis:            http-client backend using the OpenSSL library.
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client
@@ -21,7 +21,7 @@ library
   other-extensions:    ScopedTypeVariables
   build-depends:       base >= 4.10 && < 5
                      , bytestring
-                     , http-client >= 0.2
+                     , http-client >= 0.7.3
                      , network
                      , HsOpenSSL >= 0.11.4.20
                      , HsOpenSSL-x509-system

--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for http-client
 
+## 0.7.3
+
+* Added `withSocket` to `Network.HTTP.Client.Connection`.
+
 ## 0.7.2.1
 
 * Fix bug in `useProxySecureWithoutConnect`.

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -1,5 +1,5 @@
 name:                http-client
-version:             0.7.2.1
+version:             0.7.3
 synopsis:            An HTTP client engine
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client


### PR DESCRIPTION
Hi, `http-client-openssl` currently ignores `hostAddress` from `Request` making it unsuitable for use with external DNS resolver.

This PR fixes it by establishing HTTPS connections via the same functions that are used for plain HTTP connections.

Since it adds new function to `Network.HTTP.Client.Connection` the version of `http-client` should be bumped (and `http-client` dependency version in `http-client-openssl` must be bumped as well).