### PR TITLE
use base64-bytestring instead of memory

### DIFF
--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for http-client
 
+## 0.7.4
+
+* Depend on base64-bytestring instead of memory [#453](https://github.com/snoyberg/http-client/pull/453)
+
 ## 0.7.3
 
 * Added `withSocket` to `Network.HTTP.Client.Connection`.

--- a/http-client/Network/HTTP/Client/Request.hs
+++ b/http-client/Network/HTTP/Client/Request.hs
@@ -63,7 +63,7 @@ import Network.URI (URI (..), URIAuth (..), parseURI, relativeTo, escapeURIStrin
 import Control.Exception (throw, throwIO, IOException)
 import qualified Control.Exception as E
 import qualified Data.CaseInsensitive as CI
-import qualified Data.ByteArray.Encoding as BAE
+import qualified Data.ByteString.Base64 as B64
 
 import Network.HTTP.Client.Body
 import Network.HTTP.Client.Types
@@ -326,7 +326,7 @@ buildBasicAuth ::
     -> S8.ByteString -- ^ Password
     -> S8.ByteString
 buildBasicAuth user passwd =
-    S8.append "Basic " (BAE.convertToBase BAE.Base64 (S8.concat [ user, ":", passwd ]))
+    S8.append "Basic " (B64.encode (S8.concat [ user, ":", passwd ]))
 
 -- | Add a Basic Auth header (with the specified user name and password) to the
 -- given Request. Ignore error handling:

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -49,7 +49,7 @@ library
                      , transformers
                      , deepseq           >= 1.3    && <1.5
                      , case-insensitive  >= 1.0
-                     , memory            >= 0.7
+                     , base64-bytestring >= 1.0
                      , cookie
                      , exceptions        >= 0.4
                      , array

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -1,5 +1,5 @@
 name:                http-client
-version:             0.7.3
+version:             0.7.4
 synopsis:            An HTTP client engine
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client


### PR DESCRIPTION
Only a tiny piece of `memory` was used, and we also get rid of the transitive dependency on `basement`.

Can add version bump and changelog if desired.