### PR TITLE
Add setRequestResponseTimeout convenience function

### DIFF
--- a/http-conduit/ChangeLog.md
+++ b/http-conduit/ChangeLog.md
@@ -3,6 +3,7 @@
 ## 2.3.8
 
 * Adds `setRequestBearerAuth` convenience function. Note that this is only available for `http-client` versions 0.7.6 or greater. [#457](https://github.com/snoyberg/http-client/pull/457/files)
+* Adds a convenience function to set a request's response timeout [#456](https://github.com/snoyberg/http-client/pull/456)
 
 ## 2.3.7.4
 

--- a/http-conduit/Network/HTTP/Simple.hs
+++ b/http-conduit/Network/HTTP/Simple.hs
@@ -81,6 +81,7 @@ module Network.HTTP.Simple
 #endif
     , setRequestManager
     , setRequestProxy
+    , setRequestResponseTimeout
       -- * Response lenses
     , getResponseStatus
     , getResponseStatusCode
@@ -482,6 +483,12 @@ setRequestManager x req = req { HI.requestManagerOverride = Just x }
 -- @since 2.1.10
 setRequestProxy :: Maybe H.Proxy -> H.Request -> H.Request
 setRequestProxy x req = req { H.proxy = x }
+
+-- | Set the maximum time to wait for a response
+--
+-- @since 2.3.8
+setRequestResponseTimeout :: H.ResponseTimeout -> H.Request -> H.Request
+setRequestResponseTimeout x req = req { H.responseTimeout = x }
 
 -- | Get the status of the response
 --


### PR DESCRIPTION
I like to use the convenience functions, and it's been annoying this one is missing.

I haven't tested this in practice, but this seems pretty straightforward too?