### PR TITLE
Add bearer auth functions

### DIFF
--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 0.7.6
 
-* Add `applyBearerAuth` function []()
+* Add `applyBearerAuth` function [#457](https://github.com/snoyberg/http-client/pull/457/files)
 
 ## 0.7.5
 

--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for http-client
 
+## 0.7.6
+
+* Add `applyBearerAuth` function []()
+
 ## 0.7.5
 
 * Force closing connections in case of exceptions throwing [#454](https://github.com/snoyberg/http-client/pull/454).

--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -138,6 +138,7 @@ module Network.HTTP.Client
     , requestFromURI_
     , defaultRequest
     , applyBasicAuth
+    , applyBearerAuth
     , urlEncodedBody
     , getUri
     , setRequestIgnoreStatus

--- a/http-client/Network/HTTP/Client/Request.hs
+++ b/http-client/Network/HTTP/Client/Request.hs
@@ -23,6 +23,7 @@ module Network.HTTP.Client.Request
     , addProxy
     , applyBasicAuth
     , applyBasicProxyAuth
+    , applyBearerAuth
     , urlEncodedBody
     , needsGunzip
     , requestBuilder
@@ -343,6 +344,22 @@ applyBasicAuth user passwd req =
     req { requestHeaders = authHeader : requestHeaders req }
   where
     authHeader = (CI.mk "Authorization", buildBasicAuth user passwd)
+
+-- | Build a bearer-auth header value
+buildBearerAuth ::
+    S8.ByteString -- ^ Token
+    -> S8.ByteString
+buildBearerAuth token =
+    S8.append "Bearer " token
+
+-- | Add a Bearer Auth header to the given 'Request'
+--
+-- @since 0.7.6
+applyBearerAuth :: S.ByteString -> Request -> Request
+applyBearerAuth bearerToken req =
+    req { requestHeaders = authHeader : requestHeaders req }
+  where
+    authHeader = (CI.mk "Authorization", buildBearerAuth bearerToken)
 
 -- | Add a proxy to the Request so that the Request when executed will use
 -- the provided proxy.

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -1,5 +1,5 @@
 name:                http-client
-version:             0.7.5
+version:             0.7.6
 synopsis:            An HTTP client engine
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client

--- a/http-client/test/Network/HTTP/ClientSpec.hs
+++ b/http-client/test/Network/HTTP/ClientSpec.hs
@@ -33,6 +33,18 @@ spec = describe "Client" $ do
             man <- newManager defaultManagerSettings
             res <- httpLbs req man
             responseStatus res `shouldBe` status405
+    describe "bearer auth" $ do
+        it "success" $ do
+            initialReq <- parseUrlThrow "http://httpbin.org/bearer"
+            let finalReq = applyBearerAuth "token" initialReq
+            man <- newManager defaultManagerSettings
+            res <- httpLbs finalReq man
+            responseStatus res `shouldBe` status200
+        it "failure" $ do
+            req <- parseRequest "http://httpbin.org/bearer"
+            man <- newManager defaultManagerSettings
+            res <- httpLbs req man
+            responseStatus res `shouldBe` status401
 
     describe "redirects" $ do
         xit "follows redirects" $ do

--- a/http-conduit/ChangeLog.md
+++ b/http-conduit/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 2.3.8
 
-* Adds `setRequestBearerAuth` convenience function. Note that this is only available for `http-client` versions 0.7.6 or greater. []()
+* Adds `setRequestBearerAuth` convenience function. Note that this is only available for `http-client` versions 0.7.6 or greater. [#457](https://github.com/snoyberg/http-client/pull/457/files)
 
 ## 2.3.7.4
 

--- a/http-conduit/ChangeLog.md
+++ b/http-conduit/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for http-conduit
 
+## 2.3.8
+
+* Adds `setRequestBearerAuth` convenience function. Note that this is only available for `http-client` versions 0.7.6 or greater. []()
+
 ## 2.3.7.4
 
 * Introduces the `aeson` cabal file [#448](https://github.com/snoyberg/http-client/issues/448)

--- a/http-conduit/Network/HTTP/Simple.hs
+++ b/http-conduit/Network/HTTP/Simple.hs
@@ -76,6 +76,9 @@ module Network.HTTP.Simple
     , H.setRequestIgnoreStatus
     , H.setRequestCheckStatus
     , setRequestBasicAuth
+#if MIN_VERSION_http_client(0,7,6)
+    , setRequestBearerAuth
+#endif
     , setRequestManager
     , setRequestProxy
       -- * Response lenses
@@ -456,6 +459,16 @@ setRequestBasicAuth :: S.ByteString -- ^ username
                     -> H.Request
                     -> H.Request
 setRequestBasicAuth = H.applyBasicAuth
+
+#if MIN_VERSION_http_client(0,7,6)
+-- | Set bearer auth with the given token
+--
+-- @since 2.3.8
+setRequestBearerAuth :: S.ByteString -- ^ token
+                    -> H.Request
+                    -> H.Request
+setRequestBearerAuth = H.applyBearerAuth
+#endif
 
 -- | Instead of using the default global 'H.Manager', use the supplied
 -- @Manager@.

--- a/http-conduit/http-conduit.cabal
+++ b/http-conduit/http-conduit.cabal
@@ -1,6 +1,6 @@
 cabal-version:   >= 1.10
 name:            http-conduit
-version:         2.3.7.4
+version:         2.3.8
 license:         BSD3
 license-file:    LICENSE
 author:          Michael Snoyman <michael@snoyman.com>


### PR DESCRIPTION
Closes #455

Notably different from #455, I researched some more and bearer auth does _not_ imply base64 encoding the way basic auth does.

Also fwiw, many tools (eg curl) don't seem to have bearer auth helper functions. That said, still seems nice to have to me?

I tested this addition on a real API as well as the added httpbin tests