### PR TITLE
Alternative managerModifyResponse' hook

### DIFF
--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -108,6 +108,7 @@ module Network.HTTP.Client
     , managerIdleConnectionCount
     , managerModifyRequest
     , managerModifyResponse
+    , managerModifyResponse'
       -- *** Manager proxy settings
     , managerSetProxy
     , managerSetInsecureProxy

--- a/http-client/Network/HTTP/Client/Core.hs
+++ b/http-client/Network/HTTP/Client/Core.hs
@@ -204,9 +204,10 @@ responseOpen inputReq manager' = do
   wrapExc req0 $ mWrapException manager req0 $ do
     (req, res) <- go manager (redirectCount req0) req0
     checkResponse req req res
-    mModifyResponse manager res
-        { responseBody = wrapExc req0 (responseBody res)
-        }
+    res' <- mModifyResponse manager res
+                { responseBody = wrapExc req0 (responseBody res)
+                }
+    mModifyResponse' manager inputReq res'
   where
     wrapExc :: Request -> IO a -> IO a
     wrapExc req0 = handle $ throwIO . toHttpException req0

--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -90,6 +90,7 @@ defaultManagerSettings = ManagerSettings
     , managerIdleConnectionCount = 512
     , managerModifyRequest = return
     , managerModifyResponse = return
+    , managerModifyResponse' = const return
     , managerProxyInsecure = defaultProxy
     , managerProxySecure = defaultProxy
     }
@@ -127,6 +128,7 @@ newManager ms = do
             , mWrapException = managerWrapException ms
             , mModifyRequest = managerModifyRequest ms
             , mModifyResponse = managerModifyResponse ms
+            , mModifyResponse' = managerModifyResponse' ms
             , mSetProxy = \req ->
                 if secure req
                     then httpsProxy req

--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -773,6 +773,14 @@ data ManagerSettings = ManagerSettings
     -- Default: no modification
     --
     -- @since 0.5.5
+    , managerModifyResponse' :: Request -> Response BodyReader -> IO (Response BodyReader)
+    -- ^ Perform the given modification to a @Response@ after receiving it.
+    --
+    -- The original @Request@ is passed to the modification function for additional context.
+    --
+    -- Default: no modification
+    --
+    -- @since x.x.x
     , managerProxyInsecure :: ProxyOverride
     -- ^ How HTTP proxy server settings should be discovered.
     --
@@ -810,6 +818,7 @@ data Manager = Manager
     , mModifyRequest :: Request -> IO Request
     , mSetProxy :: Request -> Request
     , mModifyResponse      :: Response BodyReader -> IO (Response BodyReader)
+    , mModifyResponse'     :: Request -> Response BodyReader -> IO (Response BodyReader)
     -- ^ See 'managerProxy'
     }
     deriving T.Typeable


### PR DESCRIPTION
Hello, 

I am using the `managerModifyRequest` and `managerModifyResponse` hooks to implement a simple logging Middleware. Unfortunatelly I did not find any elegant way to access the `Request` a particular `Response` is related to. Please treat this _Pull Request_ as a preliminary proposal. I am open for changes/suggestions.

Example usage of the alternative hook: 

```
main :: IO ()
main = do
  manager <- newManager defaultManagerSettings { managerModifyResponse' = logRsp }
  request <- parseRequest "http://httpbin.org/get"
  response <- httpLbs request manager
  print $ responseBody response
  where
    logRsp :: Request -> Response a -> IO (Response a)
    logRsp request response = do
      putStrLn $  "Response to request: " <> show (path request) <> " = "
                                          <> show (responseStatus response)
      pure response

```