### PR TITLE
Add original Request to the Response type.

### DIFF
--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for http-client
 
+## 0.7.8
+
+* Include the original `Request` in the `Response`. Expose it via `getOriginalRequest`.
+
 ## 0.7.7
 
 * Allow secure cookies for localhost without HTTPS [#460](https://github.com/snoyberg/http-client/pull/460)

--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -181,6 +181,7 @@ module Network.HTTP.Client
     , responseHeaders
     , responseBody
     , responseCookieJar
+    , getOriginalRequest
     , throwErrorStatusCodes
       -- ** Response body
     , BodyReader

--- a/http-client/Network/HTTP/Client/Response.hs
+++ b/http-client/Network/HTTP/Client/Response.hs
@@ -4,6 +4,7 @@ module Network.HTTP.Client.Response
     ( getRedirectedRequest
     , getResponse
     , lbsResponse
+    , getOriginalRequest
     ) where
 
 import Data.ByteString (ByteString)
@@ -123,6 +124,7 @@ getResponse timeout' req@(Request {..}) mconn cont = do
         , responseBody = body
         , responseCookieJar = Data.Monoid.mempty
         , responseClose' = ResponseClose (cleanup False)
+        , responseOriginalRequest = req {requestBody = ""}
         }
 
 -- | Does this response have no body?
@@ -133,3 +135,11 @@ hasNoBody "HEAD" _ = True
 hasNoBody _ 204 = True
 hasNoBody _ 304 = True
 hasNoBody _ i = 100 <= i && i < 200
+
+-- | Retrieve the orignal 'Request' from a 'Response'
+--
+-- Note that the 'requestBody' is not available and always set to empty.
+--
+-- @since 0.7.8
+getOriginalRequest :: Response a -> Request
+getOriginalRequest = responseOriginalRequest

--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -690,6 +690,12 @@ data Response body = Response
     -- be impossible.
     --
     -- Since 0.1.0
+    , responseOriginalRequest :: Request
+    -- ^ Holds original @Request@ related to this @Response@ (with an empty body).
+    -- This field is intentionally not exported directly, but made availble
+    -- via @getOriginalRequest@ instead.
+    --
+    -- Since 0.7.8
     }
     deriving (Show, T.Typeable, Functor, Data.Foldable.Foldable, Data.Traversable.Traversable)
 

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -1,5 +1,5 @@
 name:                http-client
-version:             0.7.7
+version:             0.7.8
 synopsis:            An HTTP client engine
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client


### PR DESCRIPTION
Another proposal to get the original Request within `managerModifyResponse`.

Example usage:
```
main :: IO ()
main = do
  manager <- newManager defaultManagerSettings { managerModifyResponse = logRsp }
  request <- parseRequest "http://httpbin.org/get"
  response <- httpLbs request manager
  print $ responseBody response
  where
    logRsp :: Response a -> IO (Response a)
    logRsp response = do
      putStrLn $  "Response to request: " <> show (path $ responseOriginalRequest response) <> " = "
                                          <> show (responseStatus response)
      pure response
```

