### PR TITLE
Route Popper exceptions around onRequestBodyException handler.

### DIFF
--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -1,5 +1,10 @@
 # Changelog for http-client
 
+## 0.7.9
+
+* Exceptions from streamed request body now cause the request to fail. Previously they were
+  routed through onRequestBodyException and, by default, the IOExceptions were discarded.
+
 ## 0.7.8
 
 * Include the original `Request` in the `Response`. Expose it via `getOriginalRequest`.

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -1,5 +1,5 @@
 name:                http-client
-version:             0.7.8
+version:             0.7.9
 synopsis:            An HTTP client engine
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client


### PR DESCRIPTION
Exceptions thrown in the Popper (streaming request body) are routed around the `onRequestBodyException` handler. 

Previously if the Popper has thrown an exception, the default handler would silently discard that. Even installing custom handler made it impossible to distinguish between these kind of exceptions, resulting in timed out requests instead of immediate failure.

See #469 