### PR TITLE
Document Network.HTTP.Client.OpenSSL

### DIFF
--- a/http-client-openssl/Network/HTTP/Client/OpenSSL.hs
+++ b/http-client-openssl/Network/HTTP/Client/OpenSSL.hs
@@ -85,10 +85,10 @@ opensslManagerSettings mkContext = defaultManagerSettings
            (SSL.write ssl)
            (N.close sock)
 
--- same as Data.ByteString.Lazy.Internal.defaultChunkSize
-bufSize :: Int
-bufSize = 32 * 1024 - overhead
-    where overhead = 2 * sizeOf (undefined :: Int)
+    -- same as Data.ByteString.Lazy.Internal.defaultChunkSize
+    bufSize :: Int
+    bufSize = 32 * 1024 - overhead
+        where overhead = 2 * sizeOf (undefined :: Int)
 
 defaultMakeContext :: OpenSSLSettings -> IO SSL.SSLContext
 defaultMakeContext OpenSSLSettings{..} = do

--- a/http-client-openssl/Network/HTTP/Client/OpenSSL.hs
+++ b/http-client-openssl/Network/HTTP/Client/OpenSSL.hs
@@ -2,12 +2,14 @@
 {-# LANGUAGE ScopedTypeVariables #-}
 -- | Support for making connections via the OpenSSL library.
 module Network.HTTP.Client.OpenSSL
-    ( withOpenSSL
-    , newOpenSSLManager
+    ( -- * Settings
+      newOpenSSLManager
     , opensslManagerSettings
     , defaultMakeContext
     , OpenSSLSettings(..)
     , defaultOpenSSLSettings
+      -- * Re-exports from OpenSSL
+    , OpenSSL.withOpenSSL
     ) where
 
 import Network.HTTP.Client
@@ -15,9 +17,9 @@ import Network.HTTP.Client.Internal
 import Control.Exception
 import Control.Monad.IO.Class
 import Network.Socket.ByteString (sendAll, recv)
-import OpenSSL
 import qualified Data.ByteString as S
 import qualified Network.Socket as N
+import qualified OpenSSL
 import qualified OpenSSL.Session as SSL
 import qualified OpenSSL.X509.SystemStore as SSL (contextLoadSystemCerts)
 import Foreign.Storable (sizeOf)

--- a/http-client-openssl/Network/HTTP/Client/OpenSSL.hs
+++ b/http-client-openssl/Network/HTTP/Client/OpenSSL.hs
@@ -1,6 +1,5 @@
 {-# LANGUAGE RecordWildCards #-}
 {-# LANGUAGE ScopedTypeVariables #-}
-{-# LANGUAGE CPP #-}
 -- | Support for making connections via the OpenSSL library.
 module Network.HTTP.Client.OpenSSL
     ( withOpenSSL

--- a/http-client-openssl/Network/HTTP/Client/OpenSSL.hs
+++ b/http-client-openssl/Network/HTTP/Client/OpenSSL.hs
@@ -105,11 +105,17 @@ defaultMakeContext OpenSSLSettings{..} = do
     osslSettingsLoadCerts ctx
     return ctx
 
+-- | SSL settings as used by 'defaultMakeContext' to set up an 'SSL.SSLContext'.
 data OpenSSLSettings = OpenSSLSettings
     { osslSettingsOptions :: [SSL.SSLOption]
+      -- ^ SSL options, as passed to 'SSL.contextAddOption'
     , osslSettingsVerifyMode :: SSL.VerificationMode
+      -- ^ SSL verification mode, as passed to 'SSL.contextSetVerificationMode'
     , osslSettingsCiphers :: String
+      -- ^ SSL cipher list, as passed to 'SSL.contextSetCiphers'
     , osslSettingsLoadCerts :: SSL.SSLContext -> IO ()
+      -- ^ An action to load certificates into the context, typically using
+      -- 'SSL.contextSetCAFile' or 'SSL.contextSetCaDirectory'.
     }
 
 -- | Default OpenSSL settings. In particular:


### PR DESCRIPTION
I had to read the source to understand what's going on with `makeDefaultContext` in particular. I can't say I really understand the reasoning behind the API design, so it's quite possible this could be improved, but at least it should be apparent now that `newOpenSSLManager` isn't just `newManager $ openSSLManagerSettings $ defaultMakeContext defaultOpenSSLSettings` as one might expect.