### PR TITLE
Asynchronous search for successful IP

### DIFF
--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for http-client
 
+## 0.7.10
+
+* Search for reachable IP addresses asynchronously (RFC 6555) after calling `getAddrInfo` to reduce latency [#462](https://github.com/snoyberg/http-client/pull/472).
+
 ## 0.7.9
 
 * Exceptions from streamed request body now cause the request to fail. Previously they were

--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 0.7.10
 
-* Search for reachable IP addresses asynchronously (RFC 6555, 8305) after calling `getAddrInfo` to reduce latency [#462](https://github.com/snoyberg/http-client/pull/472).
+* Search for reachable IP addresses asynchronously (RFC 6555, 8305) after calling `getAddrInfo` to reduce latency [#472](https://github.com/snoyberg/http-client/pull/472).
 
 ## 0.7.9
 

--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -2,7 +2,7 @@
 
 ## 0.7.10
 
-* Search for reachable IP addresses asynchronously (RFC 6555) after calling `getAddrInfo` to reduce latency [#462](https://github.com/snoyberg/http-client/pull/472).
+* Search for reachable IP addresses asynchronously (RFC 6555, 8305) after calling `getAddrInfo` to reduce latency [#462](https://github.com/snoyberg/http-client/pull/472).
 
 ## 0.7.9
 

--- a/http-client/Network/HTTP/Client/Connection.hs
+++ b/http-client/Network/HTTP/Client/Connection.hs
@@ -214,6 +214,6 @@ firstSuccessful addresses cb = do
                 go addrs $ a : asyncs
 
         tryAddress addr = do
-            r :: Either E.IOException a <- E.try $ cb addr
+            r :: Either E.IOException a <- E.try $! cb addr
             for_ r $ \_ -> tryPutMVar result r
             pure r

--- a/http-client/Network/HTTP/Client/Connection.hs
+++ b/http-client/Network/HTTP/Client/Connection.hs
@@ -187,7 +187,7 @@ openSocket tweakSocket addr =
             NS.connect sock (NS.addrAddress addr)
             return sock)
 
--- Resolve using an approximation of the happy-eyeballs algorithm:
+-- Pick up an IP using an approximation of the happy-eyeballs algorithm:
 -- https://datatracker.ietf.org/doc/html/rfc8305
 -- 
 firstSuccessful :: [NS.AddrInfo] -> (NS.AddrInfo -> IO a) -> IO a
@@ -222,7 +222,7 @@ firstSuccessful addresses cb = do
                 z  ->
                     case [ r | Right r <- z ] of
                         []
-                            -- tried all of them, but there's no successful ones
+                            -- tried all of them, but there're no successful ones
                             | length z == totalSize -> 
                                 throwSTM $ head [ e :: E.SomeException | Left e <- z ]
 

--- a/http-client/Network/HTTP/Client/Connection.hs
+++ b/http-client/Network/HTTP/Client/Connection.hs
@@ -209,11 +209,11 @@ firstSuccessful addresses cb = do
       where
         go []             asyncs = mapM wait asyncs
         go (addr : addrs) asyncs =
-            withAsync (tryAddress addr) $ \a -> do
+            withAsync (E.evaluate =<< tryAddress addr) $ \a -> do
                 unless (null addrs) $ threadDelay connectionAttemptDelay
                 go addrs $ a : asyncs
 
         tryAddress addr = do
-            r :: Either E.IOException a <- E.try $! cb addr
+            r :: Either E.IOException a <- E.try $ cb addr
             for_ r $ \_ -> tryPutMVar result r
             pure r

--- a/http-client/Network/HTTP/Client/Connection.hs
+++ b/http-client/Network/HTTP/Client/Connection.hs
@@ -209,11 +209,11 @@ firstSuccessful addresses cb = do
       where
         go []             asyncs = mapM wait asyncs
         go (addr : addrs) asyncs =
-            withAsync (E.evaluate =<< tryAddress addr) $ \a -> do
+            withAsync (tryAddress addr) $ \a -> do
                 unless (null addrs) $ threadDelay connectionAttemptDelay
                 go addrs $ a : asyncs
 
         tryAddress addr = do
             r :: Either E.IOException a <- E.try $ cb addr
             for_ r $ \_ -> tryPutMVar result r
-            pure r
+            pure $! r

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -1,5 +1,5 @@
 name:                http-client
-version:             0.7.9
+version:             0.7.10
 synopsis:            An HTTP client engine
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -59,7 +59,7 @@ library
                      , ghc-prim
                      , stm               >= 2.3
                      , iproute           >= 1.7.5
-                     , async             >= 2.2.2
+                     , async
   if flag(network-uri)
     build-depends: network >= 2.6, network-uri >= 2.6
   else

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -59,6 +59,7 @@ library
                      , ghc-prim
                      , stm               >= 2.3
                      , iproute           >= 1.7.5
+                     , async             >= 2.2.2
   if flag(network-uri)
     build-depends: network >= 2.6, network-uri >= 2.6
   else


### PR DESCRIPTION
This is to introduce a minimal (and not complete) implementation of RFC 6555 and RFC 8305. 

- Instead of doing manual asynchronous DNS lookup for AAAA and A records, it relies on getAddrInfo.
- Available IP addresses are chosen concurrently.

The reason for the change is to avoid long timeouts when a domain has AAAA DNS record but no IPv6 connectivity, which is a relatively common misconfiguration.