### PR TITLE
Add cabal.project

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,1 @@
+packages: */*.cabal


### PR DESCRIPTION
With this, calling e.g. `cabal build` from within `http-client-tls`
will build `http-client` from the local tree instead of hackage,
which is convenient when making changes across multiple packages.

No idea what you think about this or whether there's downsides I'm
not aware of, but I found it very useful while working on #477, so
thought I'd share.