### PR TITLE
Prelude.<> was added in base-4.11

### DIFF
--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -65,7 +65,7 @@ library
   else
     build-depends: network < 2.6
 
-  if !impl(ghc>=8.0)
+  if !impl(ghc>=8.4)
     build-depends: semigroups >= 0.16.1
 
   -- See build failure at https://travis-ci.org/snoyberg/http-client/jobs/359573631


### PR DESCRIPTION
This avoids a build failure with ghc-8.2.

(The alternative would be to import semigroups for old ghc's)

eg https://github.com/juhp/fbrnch/runs/5152510660