### PR TITLE
Prevent connections from being closed too early due to weak refs expiring

### DIFF
--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for http-client
 
+## 0.7.12
+
+* Fix premature connection closing due to weak reference lifetimes [#490](https://github.com/snoyberg/http-client/pull/490)
+
 ## 0.7.11
 
 * Allow making requests to raw IPv6 hosts [#477](https://github.com/snoyberg/http-client/pull/477)

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -1,5 +1,5 @@
 name:                http-client
-version:             0.7.11
+version:             0.7.12
 synopsis:            An HTTP client engine
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client


### PR DESCRIPTION
Fixes https://github.com/snoyberg/http-client/issues/489, see that issue or the included test for a description of the problem.