### PR TITLE
Create the ability to redact custom header values to censor sensitive information

### DIFF
--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for http-client
 
+## 0.7.13
+
+* Create the ability to redact custom header values to censor sensitive information
+
 ## 0.7.12
 
 * Fix premature connection closing due to weak reference lifetimes [#490](https://github.com/snoyberg/http-client/pull/490)

--- a/http-client/Network/HTTP/Client/Request.hs
+++ b/http-client/Network/HTTP/Client/Request.hs
@@ -49,6 +49,7 @@ import Control.Applicative as A ((<$>))
 import Control.Monad (unless, guard)
 import Control.Monad.IO.Class (MonadIO, liftIO)
 import Numeric (showHex)
+import qualified Data.Set as Set
 
 import Blaze.ByteString.Builder (Builder, fromByteString, fromLazyByteString, toByteStringIO, flush)
 import Blaze.ByteString.Builder.Char8 (fromChar, fromShow)
@@ -303,6 +304,7 @@ defaultRequest = Request
         , requestManagerOverride = Nothing
         , shouldStripHeaderOnRedirect = const False
         , proxySecureMode = ProxySecureWithConnect
+        , redactHeaders = Set.singleton "Authorization"
         }
 
 -- | Parses a URL via 'parseRequest_'

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -1,5 +1,5 @@
 name:                http-client
-version:             0.7.12
+version:             0.7.13
 synopsis:            An HTTP client engine
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client


### PR DESCRIPTION
Create the ability to redact custom header values to censor sensitive information.

Currently only the header field "Authorization" is redacted. That is useful, but we need to add custom fields, as different platforms use different header fields for authentication.

If this is approved - I'll add PR to "req" client, where this package is used.