### PR TITLE
Require async >= 2.0

### DIFF
--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -59,7 +59,7 @@ library
                      , ghc-prim
                      , stm               >= 2.3
                      , iproute           >= 1.7.5
-                     , async
+                     , async             >= 2.0
   if flag(network-uri)
     build-depends: network >= 2.6, network-uri >= 2.6
   else


### PR DESCRIPTION
`Control.Concurrent.Async` module is not provided before `async-2.0.0.0`.