### PR TITLE
Add attoparsec-aeson dependency

### DIFF
--- a/http-conduit/http-conduit.cabal
+++ b/http-conduit/http-conduit.cabal
@@ -42,6 +42,7 @@ library
 
     if flag(aeson)
       build-depends: aeson                 >= 0.8
+                   , attoparsec-aeson      >= 2.2
 
     if !impl(ghc>=7.9)
       build-depends:   void >= 0.5.5


### PR DESCRIPTION
This will enable compatibility with aeson-2.2 when it's released. aeson-2.2 moves the `Data.Aeson.Parser` module into a separate package (attoparsec-aeson).