### PR TITLE
http-conduit: depend on attoparsec-aeson to allow aeson-2.2

### DIFF
--- a/http-conduit/http-conduit.cabal
+++ b/http-conduit/http-conduit.cabal
@@ -42,6 +42,7 @@ library
 
     if flag(aeson)
       build-depends: aeson                 >= 0.8
+                   , attoparsec-aeson      >= 2.1
 
     if !impl(ghc>=7.9)
       build-depends:   void >= 0.5.5
@@ -90,6 +91,7 @@ test-suite test
 
     if flag(aeson)
       build-depends: aeson
+                   , attoparsec-aeson      >= 2.1
 
 source-repository head
   type:     git

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,4 +1,4 @@
-resolver: lts-20.24
+resolver: lts-20.26
 packages:
 - http-client
 - http-client-tls
@@ -18,3 +18,4 @@ extra-deps:
 - warp-tls-3.3.7
 - recv-0.1.0
 - http2-4.1.3
+- attoparsec-aeson-2.1.0.0


### PR DESCRIPTION
replaces #510
closes #511