### PR TITLE
Allow customizing max header length

### DIFF
--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -210,7 +210,7 @@ module Network.HTTP.Client
     ) where
 
 import Network.HTTP.Client.Body
-import Network.HTTP.Client.Connection (makeConnection, socketConnection, strippedHostName, MaxHeaderLength)
+import Network.HTTP.Client.Connection (makeConnection, socketConnection, strippedHostName)
 import Network.HTTP.Client.Cookies
 import Network.HTTP.Client.Core
 import Network.HTTP.Client.Manager

--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -252,13 +252,13 @@ data HistoriedResponse body = HistoriedResponse
 -- response bodies.
 --
 -- Since 0.4.1
-responseOpenHistory :: MaxHeaderLength -> Request -> Manager -> IO (HistoriedResponse BodyReader)
-responseOpenHistory mhl reqOrig man0 = handle (throwIO . toHttpException reqOrig) $ do
+responseOpenHistory :: Request -> Manager -> IO (HistoriedResponse BodyReader)
+responseOpenHistory reqOrig man0 = handle (throwIO . toHttpException reqOrig) $ do
     reqRef <- newIORef reqOrig
     historyRef <- newIORef id
     let go req0 = do
             (man, req) <- getModifiedRequestManager man0 req0
-            (req', res') <- httpRaw' mhl req man
+            (req', res') <- httpRaw' req man
             let res = res'
                     { responseBody = handle (throwIO . toHttpException req0)
                                             (responseBody res')
@@ -289,13 +289,12 @@ responseOpenHistory mhl reqOrig man0 = handle (throwIO . toHttpException reqOrig
 -- response bodies.
 --
 -- Since 0.4.1
-withResponseHistory :: MaxHeaderLength
-                    -> Request
+withResponseHistory :: Request
                     -> Manager
                     -> (HistoriedResponse BodyReader -> IO a)
                     -> IO a
-withResponseHistory mhl req man = bracket
-    (responseOpenHistory mhl req man)
+withResponseHistory req man = bracket
+    (responseOpenHistory req man)
     (responseClose . hrFinalResponse)
 
 -- | Set the proxy override value, only for HTTP (insecure) connections.

--- a/http-client/Network/HTTP/Client/Body.hs
+++ b/http-client/Network/HTTP/Client/Body.hs
@@ -148,7 +148,7 @@ makeLengthReader cleanup count0 Connection {..} = do
                         return bs
 
 makeChunkedReader
-  :: MaxHeaderLength
+  :: Maybe MaxHeaderLength
   -> IO () -- ^ cleanup
   -> Bool -- ^ raw
   -> Connection

--- a/http-client/Network/HTTP/Client/Connection.hs
+++ b/http-client/Network/HTTP/Client/Connection.hs
@@ -31,10 +31,6 @@ import Data.Function (fix)
 import Data.Maybe (listToMaybe)
 import Data.Word (Word8)
 
-newtype MaxHeaderLength
-    = MaxHeaderLength Int
-    deriving (Eq, Show)
-
 connectionReadLine :: MaxHeaderLength -> Connection -> IO ByteString
 connectionReadLine mhl conn = do
     bs <- connectionRead conn

--- a/http-client/Network/HTTP/Client/Connection.hs
+++ b/http-client/Network/HTTP/Client/Connection.hs
@@ -43,14 +43,14 @@ connectionDropTillBlankLine mhl conn = fix $ \loop -> do
     unless (S.null bs) loop
 
 connectionReadLineWith :: MaxHeaderLength -> Connection -> ByteString -> IO ByteString
-connectionReadLineWith (MaxHeaderLength mhl) conn bs0 =
+connectionReadLineWith mhl conn bs0 =
     go bs0 id 0
   where
     go bs front total =
         case S.break (== charLF) bs of
             (_, "") -> do
                 let total' = total + S.length bs
-                when (total' > mhl) $ throwHttp OverlongHeaders
+                when (total' > unMaxHeaderLength mhl) $ throwHttp OverlongHeaders
                 bs' <- connectionRead conn
                 when (S.null bs') $ throwHttp IncompleteHeaders
                 go bs' (front . (bs:)) total'

--- a/http-client/Network/HTTP/Client/Connection.hs
+++ b/http-client/Network/HTTP/Client/Connection.hs
@@ -2,8 +2,7 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE ViewPatterns #-}
 module Network.HTTP.Client.Connection
-    ( MaxHeaderLength (..)
-    , connectionReadLine
+    ( connectionReadLine
     , connectionReadLineWith
     , connectionDropTillBlankLine
     , dummyConnection

--- a/http-client/Network/HTTP/Client/Core.hs
+++ b/http-client/Network/HTTP/Client/Core.hs
@@ -32,6 +32,7 @@ import Control.Monad (void)
 import System.Timeout (timeout)
 import Data.KeyedPool
 import GHC.IO.Exception (IOException(..), IOErrorType(..))
+import Network.HTTP.Client.Connection (MaxHeaderLength)
 
 -- | Perform a @Request@ using a connection acquired from the given @Manager@,
 -- and then provide the @Response@ to the given function. This function is
@@ -47,11 +48,12 @@ import GHC.IO.Exception (IOException(..), IOErrorType(..))
 -- body.
 --
 -- Since 0.1.0
-withResponse :: Request
+withResponse :: MaxHeaderLength
+             -> Request
              -> Manager
              -> (Response BodyReader -> IO a)
              -> IO a
-withResponse req man f = bracket (responseOpen req man) responseClose f
+withResponse mhl req man f = bracket (responseOpen mhl req man) responseClose f
 
 -- | A convenience wrapper around 'withResponse' which reads in the entire
 -- response body and immediately closes the connection. Note that this function
@@ -60,8 +62,8 @@ withResponse req man f = bracket (responseOpen req man) responseClose f
 -- are encouraged to use 'withResponse' and 'brRead' instead.
 --
 -- Since 0.1.0
-httpLbs :: Request -> Manager -> IO (Response L.ByteString)
-httpLbs req man = withResponse req man $ \res -> do
+httpLbs :: MaxHeaderLength -> Request -> Manager -> IO (Response L.ByteString)
+httpLbs mhl req man = withResponse mhl req man $ \res -> do
     bss <- brConsume $ responseBody res
     return res { responseBody = L.fromChunks bss }
 
@@ -69,25 +71,27 @@ httpLbs req man = withResponse req man $ \res -> do
 -- body. This is useful, for example, when performing a HEAD request.
 --
 -- Since 0.3.2
-httpNoBody :: Request -> Manager -> IO (Response ())
-httpNoBody req man = withResponse req man $ return . void
+httpNoBody :: MaxHeaderLength -> Request -> Manager -> IO (Response ())
+httpNoBody mhl req man = withResponse mhl req man $ return . void
 
 
 -- | Get a 'Response' without any redirect following.
 httpRaw
-     :: Request
+     :: MaxHeaderLength
+     -> Request
      -> Manager
      -> IO (Response BodyReader)
-httpRaw = fmap (fmap snd) . httpRaw'
+httpRaw mhl = fmap (fmap snd) . httpRaw' mhl
 
 -- | Get a 'Response' without any redirect following.
 --
 -- This extended version of 'httpRaw' also returns the potentially modified Request.
 httpRaw'
-     :: Request
+     :: MaxHeaderLength
+     -> Request
      -> Manager
      -> IO (Request, Response BodyReader)
-httpRaw' req0 m = do
+httpRaw' mhl req0 m = do
     let req' = mSetProxy m req0
     (req, cookie_jar') <- case cookieJar req' of
         Just cj -> do
@@ -105,13 +109,13 @@ httpRaw' req0 m = do
     ex <- try $ do
         cont <- requestBuilder (dropProxyAuthSecure req) (managedResource mconn)
 
-        getResponse timeout' req mconn cont
+        getResponse mhl timeout' req mconn cont
 
     case ex of
         -- Connection was reused, and might have been closed. Try again
         Left e | managedReused mconn && mRetryableException m e -> do
             managedRelease mconn DontReuse
-            httpRaw' req m
+            httpRaw' mhl req m
         -- Not reused, or a non-retry, so this is a real exception
         Left e -> do
           -- Explicitly release connection for all real exceptions:
@@ -197,8 +201,8 @@ getModifiedRequestManager manager0 req0 = do
 -- headers to be relayed.
 --
 -- Since 0.1.0
-responseOpen :: Request -> Manager -> IO (Response BodyReader)
-responseOpen inputReq manager' = do
+responseOpen :: MaxHeaderLength-> Request -> Manager -> IO (Response BodyReader)
+responseOpen mhl inputReq manager' = do
   case validateHeaders (requestHeaders inputReq) of
     GoodHeaders -> return ()
     BadHeaders reason -> throwHttp $ InvalidRequestHeader reason
@@ -217,7 +221,7 @@ responseOpen inputReq manager' = do
       count
       (\req -> do
         (manager, modReq) <- getModifiedRequestManager manager0 req
-        (req'', res) <- httpRaw' modReq manager
+        (req'', res) <- httpRaw' mhl modReq manager
         let mreq = if redirectCount modReq == 0
               then Nothing
               else getRedirectedRequest req'' (responseHeaders res) (responseCookieJar res) (statusCode (responseStatus res))

--- a/http-client/Network/HTTP/Client/Core.hs
+++ b/http-client/Network/HTTP/Client/Core.hs
@@ -32,7 +32,6 @@ import Control.Monad (void)
 import System.Timeout (timeout)
 import Data.KeyedPool
 import GHC.IO.Exception (IOException(..), IOErrorType(..))
-import Network.HTTP.Client.Connection (MaxHeaderLength)
 
 -- | Perform a @Request@ using a connection acquired from the given @Manager@,
 -- and then provide the @Response@ to the given function. This function is

--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -92,6 +92,7 @@ defaultManagerSettings = ManagerSettings
     , managerModifyResponse = return
     , managerProxyInsecure = defaultProxy
     , managerProxySecure = defaultProxy
+    , managerMaxHeaderLength = MaxHeaderLength 4096
     }
 
 -- | Create a 'Manager'. The @Manager@ will be shut down automatically via

--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -132,6 +132,7 @@ newManager ms = do
                 if secure req
                     then httpsProxy req
                     else httpProxy req
+            , mMaxHeaderLength = managerMaxHeaderLength ms
             }
     return manager
 

--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -105,14 +105,14 @@ defaultManagerSettings = ManagerSettings
 -- though add-on libraries may provide a recommended replacement.
 --
 -- Since 0.1.0
-newManager :: MaxHeaderLength -> ManagerSettings -> IO Manager
-newManager mhl ms = do
+newManager :: ManagerSettings -> IO Manager
+newManager ms = do
     NS.withSocketsDo $ return ()
 
     httpProxy <- runProxyOverride (managerProxyInsecure ms) False
     httpsProxy <- runProxyOverride (managerProxySecure ms) True
 
-    createConnection <- mkCreateConnection mhl ms
+    createConnection <- mkCreateConnection ms
 
     keyedPool <- createKeyedPool
         createConnection
@@ -183,8 +183,8 @@ closeManager _ = return ()
 -- | Create, use and close a 'Manager'.
 --
 -- Since 0.2.1
-withManager :: MaxHeaderLength -> ManagerSettings -> (Manager -> IO a) -> IO a
-withManager mhl settings f = newManager mhl settings >>= f
+withManager :: ManagerSettings -> (Manager -> IO a) -> IO a
+withManager settings f = newManager settings >>= f
 {-# DEPRECATED withManager "Use newManager instead" #-}
 
 -- | Drop the Proxy-Authorization header from the request if we're using a
@@ -230,8 +230,8 @@ connKey Request { proxy = Just p, secure = True,
                   proxySecureMode = ProxySecureWithoutConnect  } =
   CKRaw Nothing (proxyHost p) (proxyPort p)
 
-mkCreateConnection :: MaxHeaderLength -> ManagerSettings -> IO (ConnKey -> IO Connection)
-mkCreateConnection mhl ms = do
+mkCreateConnection :: ManagerSettings -> IO (ConnKey -> IO Connection)
+mkCreateConnection ms = do
     rawConnection <- managerRawConnection ms
     tlsConnection <- managerTlsConnection ms
     tlsProxyConnection <- managerTlsProxyConnection ms
@@ -258,7 +258,7 @@ mkCreateConnection mhl ms = do
                     , "\r\n"
                     ]
                 parse conn = do
-                    StatusHeaders status _ _ <- parseStatusHeaders mhl conn Nothing Nothing
+                    StatusHeaders status _ _ <- parseStatusHeaders (managerMaxHeaderLength ms) conn Nothing Nothing
                     unless (status == status200) $
                         throwHttp $ ProxyConnectException ultHost ultPort status
                 in tlsProxyConnection

--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -92,7 +92,7 @@ defaultManagerSettings = ManagerSettings
     , managerModifyResponse = return
     , managerProxyInsecure = defaultProxy
     , managerProxySecure = defaultProxy
-    , managerMaxHeaderLength = MaxHeaderLength 4096
+    , managerMaxHeaderLength = Just $ MaxHeaderLength 4096
     }
 
 -- | Create a 'Manager'. The @Manager@ will be shut down automatically via

--- a/http-client/Network/HTTP/Client/Response.hs
+++ b/http-client/Network/HTTP/Client/Response.hs
@@ -84,7 +84,7 @@ lbsResponse res = do
         { responseBody = L.fromChunks bss
         }
 
-getResponse :: MaxHeaderLength
+getResponse :: Maybe MaxHeaderLength
             -> Maybe Int
             -> Request
             -> Managed Connection

--- a/http-client/Network/HTTP/Client/Response.hs
+++ b/http-client/Network/HTTP/Client/Response.hs
@@ -20,7 +20,6 @@ import Network.URI (parseURIReference, escapeURIString, isAllowedInURI)
 
 import Network.HTTP.Client.Types
 
-import Network.HTTP.Client.Connection (MaxHeaderLength)
 import Network.HTTP.Client.Request
 import Network.HTTP.Client.Util
 import Network.HTTP.Client.Body

--- a/http-client/Network/HTTP/Client/Response.hs
+++ b/http-client/Network/HTTP/Client/Response.hs
@@ -20,6 +20,7 @@ import Network.URI (parseURIReference, escapeURIString, isAllowedInURI)
 
 import Network.HTTP.Client.Types
 
+import Network.HTTP.Client.Connection (MaxHeaderLength)
 import Network.HTTP.Client.Request
 import Network.HTTP.Client.Util
 import Network.HTTP.Client.Body
@@ -84,14 +85,15 @@ lbsResponse res = do
         { responseBody = L.fromChunks bss
         }
 
-getResponse :: Maybe Int
+getResponse :: MaxHeaderLength
+            -> Maybe Int
             -> Request
             -> Managed Connection
             -> Maybe (IO ()) -- ^ Action to run in case of a '100 Continue'.
             -> IO (Response BodyReader)
-getResponse timeout' req@(Request {..}) mconn cont = do
+getResponse mhl timeout' req@(Request {..}) mconn cont = do
     let conn = managedResource mconn
-    StatusHeaders s version hs <- parseStatusHeaders conn timeout' cont
+    StatusHeaders s version hs <- parseStatusHeaders mhl conn timeout' cont
     let mcl = lookup "content-length" hs >>= readPositiveInt . S8.unpack
         isChunked = ("transfer-encoding", CI.mk "chunked") `elem` map (second CI.mk) hs
 
@@ -115,7 +117,7 @@ getResponse timeout' req@(Request {..}) mconn cont = do
             else do
                 body1 <-
                     if isChunked
-                        then makeChunkedReader (cleanup True) rawBody conn
+                        then makeChunkedReader mhl (cleanup True) rawBody conn
                         else
                             case mcl of
                                 Just len -> makeLengthReader (cleanup True) len conn

--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -38,6 +38,7 @@ module Network.HTTP.Client.Types
     , StreamFileStatus (..)
     , ResponseTimeout (..)
     , ProxySecureMode (..)
+    , MaxHeaderLength (..)
     ) where
 
 import qualified Data.Typeable as T (Typeable)
@@ -879,3 +880,9 @@ data StreamFileStatus = StreamFileStatus
     , thisChunkSize :: Int
     }
     deriving (Eq, Show, Ord, T.Typeable)
+
+-- | The maximum header size in bytes.
+newtype MaxHeaderLength = MaxHeaderLength
+    { unMaxHeaderLength :: Int
+    }
+    deriving (Eq, Show)

--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -803,6 +803,7 @@ data ManagerSettings = ManagerSettings
     -- Default: respect the @proxy@ value on the @Request@ itself.
     --
     -- Since 0.4.7
+    , managerMaxHeaderLength :: MaxHeaderLength
     }
     deriving T.Typeable
 

--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -803,7 +803,7 @@ data ManagerSettings = ManagerSettings
     -- Default: respect the @proxy@ value on the @Request@ itself.
     --
     -- Since 0.4.7
-    , managerMaxHeaderLength :: MaxHeaderLength
+    , managerMaxHeaderLength :: Maybe MaxHeaderLength
     }
     deriving T.Typeable
 
@@ -830,7 +830,7 @@ data Manager = Manager
     , mSetProxy :: Request -> Request
     , mModifyResponse      :: Response BodyReader -> IO (Response BodyReader)
     -- ^ See 'managerProxy'
-    , mMaxHeaderLength :: MaxHeaderLength
+    , mMaxHeaderLength :: Maybe MaxHeaderLength
     }
     deriving T.Typeable
 

--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -830,6 +830,7 @@ data Manager = Manager
     , mSetProxy :: Request -> Request
     , mModifyResponse      :: Response BodyReader -> IO (Response BodyReader)
     -- ^ See 'managerProxy'
+    , mMaxHeaderLength :: MaxHeaderLength
     }
     deriving T.Typeable
 

--- a/http-client/test-nonet/Network/HTTP/Client/BodySpec.hs
+++ b/http-client/test-nonet/Network/HTTP/Client/BodySpec.hs
@@ -22,7 +22,7 @@ spec = describe "BodySpec" $ do
         (conn, _, input) <- dummyConnection
             [ "5\r\nhello\r\n6\r\n world\r\n0\r\n\r\nnot consumed"
             ]
-        reader <- makeChunkedReader (return ()) False conn
+        reader <- makeChunkedReader Nothing (return ()) False conn
         body <- brConsume reader
         S.concat body `shouldBe` "hello world"
         input' <- input
@@ -33,7 +33,7 @@ spec = describe "BodySpec" $ do
         (conn, _, input) <- dummyConnection
             [ "5\r\nhello\r\n6\r\n world\r\n0\r\ntrailers-are: ignored\r\nbut: consumed\r\n\r\nnot consumed"
             ]
-        reader <- makeChunkedReader (return ()) False conn
+        reader <- makeChunkedReader Nothing (return ()) False conn
         body <- brConsume reader
         S.concat body `shouldBe` "hello world"
         input' <- input
@@ -43,7 +43,7 @@ spec = describe "BodySpec" $ do
     it "chunked, pieces" $ do
         (conn, _, input) <- dummyConnection $ map S.singleton $ S.unpack
             "5\r\nhello\r\n6\r\n world\r\n0\r\n\r\nnot consumed"
-        reader <- makeChunkedReader (return ()) False conn
+        reader <- makeChunkedReader Nothing (return ()) False conn
         body <- brConsume reader
         S.concat body `shouldBe` "hello world"
         input' <- input
@@ -53,7 +53,7 @@ spec = describe "BodySpec" $ do
     it "chunked, pieces, with trailers" $ do
         (conn, _, input) <- dummyConnection $ map S.singleton $ S.unpack
             "5\r\nhello\r\n6\r\n world\r\n0\r\ntrailers-are: ignored\r\nbut: consumed\r\n\r\nnot consumed"
-        reader <- makeChunkedReader (return ()) False conn
+        reader <- makeChunkedReader Nothing (return ()) False conn
         body <- brConsume reader
         S.concat body `shouldBe` "hello world"
         input' <- input
@@ -64,7 +64,7 @@ spec = describe "BodySpec" $ do
         (conn, _, input) <- dummyConnection
             [ "5\r\nhello\r\n6\r\n world\r\n0\r\n\r\nnot consumed"
             ]
-        reader <- makeChunkedReader (return ()) True conn
+        reader <- makeChunkedReader Nothing (return ()) True conn
         body <- brConsume reader
         S.concat body `shouldBe` "5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n"
         input' <- input
@@ -75,7 +75,7 @@ spec = describe "BodySpec" $ do
         (conn, _, input) <- dummyConnection
             [ "5\r\nhello\r\n6\r\n world\r\n0\r\ntrailers-are: returned\r\nin-raw: body\r\n\r\nnot consumed"
             ]
-        reader <- makeChunkedReader (return ()) True conn
+        reader <- makeChunkedReader Nothing (return ()) True conn
         body <- brConsume reader
         S.concat body `shouldBe` "5\r\nhello\r\n6\r\n world\r\n0\r\ntrailers-are: returned\r\nin-raw: body\r\n\r\n"
         input' <- input
@@ -85,7 +85,7 @@ spec = describe "BodySpec" $ do
     it "chunked, pieces, raw" $ do
         (conn, _, input) <- dummyConnection $ map S.singleton $ S.unpack
             "5\r\nhello\r\n6\r\n world\r\n0\r\n\r\nnot consumed"
-        reader <- makeChunkedReader (return ()) True conn
+        reader <- makeChunkedReader Nothing (return ()) True conn
         body <- brConsume reader
         S.concat body `shouldBe` "5\r\nhello\r\n6\r\n world\r\n0\r\n\r\n"
         input' <- input
@@ -95,7 +95,7 @@ spec = describe "BodySpec" $ do
     it "chunked, pieces, raw, with trailers" $ do
         (conn, _, input) <- dummyConnection $ map S.singleton $ S.unpack
             "5\r\nhello\r\n6\r\n world\r\n0\r\ntrailers-are: returned\r\nin-raw: body\r\n\r\nnot consumed"
-        reader <- makeChunkedReader (return ()) True conn
+        reader <- makeChunkedReader Nothing (return ()) True conn
         body <- brConsume reader
         S.concat body `shouldBe` "5\r\nhello\r\n6\r\n world\r\n0\r\ntrailers-are: returned\r\nin-raw: body\r\n\r\n"
         input' <- input

--- a/http-client/test-nonet/Network/HTTP/Client/HeadersSpec.hs
+++ b/http-client/test-nonet/Network/HTTP/Client/HeadersSpec.hs
@@ -20,7 +20,7 @@ spec = describe "HeadersSpec" $ do
                 , "\nignored"
                 ]
         (connection, _, _) <- dummyConnection input
-        statusHeaders <- parseStatusHeaders connection Nothing Nothing
+        statusHeaders <- parseStatusHeaders Nothing connection Nothing Nothing
         statusHeaders `shouldBe` StatusHeaders status200 (HttpVersion 1 1)
             [ ("foo", "bar")
             , ("baz", "bin")
@@ -34,7 +34,7 @@ spec = describe "HeadersSpec" $ do
                 ]
         (conn, out, _) <- dummyConnection input
         let sendBody = connectionWrite conn "data"
-        statusHeaders <- parseStatusHeaders conn Nothing (Just sendBody)
+        statusHeaders <- parseStatusHeaders Nothing conn Nothing (Just sendBody)
         statusHeaders `shouldBe` StatusHeaders status200 (HttpVersion 1 1) [ ("foo", "bar") ]
         out >>= (`shouldBe` ["data"])
 
@@ -44,7 +44,7 @@ spec = describe "HeadersSpec" $ do
                 ]
         (conn, out, _) <- dummyConnection input
         let sendBody = connectionWrite conn "data"
-        statusHeaders <- parseStatusHeaders conn Nothing (Just sendBody)
+        statusHeaders <- parseStatusHeaders Nothing conn Nothing (Just sendBody)
         statusHeaders `shouldBe` StatusHeaders status417 (HttpVersion 1 1) []
         out >>= (`shouldBe` [])
 
@@ -56,7 +56,7 @@ spec = describe "HeadersSpec" $ do
                 , "result"
                 ]
         (conn, out, inp) <- dummyConnection input
-        statusHeaders <- parseStatusHeaders conn Nothing Nothing
+        statusHeaders <- parseStatusHeaders Nothing conn Nothing Nothing
         statusHeaders `shouldBe` StatusHeaders status200 (HttpVersion 1 1) [ ("foo", "bar") ]
         out >>= (`shouldBe` [])
         inp >>= (`shouldBe` ["result"])

--- a/http-client/test-nonet/Network/HTTP/Client/ResponseSpec.hs
+++ b/http-client/test-nonet/Network/HTTP/Client/ResponseSpec.hs
@@ -16,7 +16,7 @@ main = hspec spec
 
 spec :: Spec
 spec = describe "ResponseSpec" $ do
-    let getResponse' conn = getResponse Nothing req (dummyManaged conn) Nothing
+    let getResponse' conn = getResponse Nothing Nothing req (dummyManaged conn) Nothing
         req = parseRequest_ "http://localhost"
     it "basic" $ do
         (conn, _, _) <- dummyConnection


### PR DESCRIPTION
Fixes #502. 

I'm not sure if this is the right way to add this customization. I turned the constant into a parameter and then just kept adding parameters until the compiler was happy. Then I pushed the configuration into the `Manager` since that felt like the right place to put it. 

Some of the function signatures could be cleaner if this configuration was contained in the `Connection`, but that didn't feel like the right place for this — for whatever reason. Also I have no idea how important it is to have a stable API for these functions. As a user of `http-client`, I basically only ever use `newManager` and `httpLbs`. 

I'm very much open to feedback here! Please let me know if I can change anything to make this easier to merge. 