### PR TITLE
Bump `deepseq` to `<1.6` for GHC 9.8

### DIFF
--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -47,7 +47,7 @@ library
                      , streaming-commons >= 0.1.0.2 && < 0.3
                      , containers        >= 0.5
                      , transformers
-                     , deepseq           >= 1.3    && <1.5
+                     , deepseq           >= 1.3    && <1.6
                      , case-insensitive  >= 1.0
                      , base64-bytestring >= 1.0
                      , cookie


### PR DESCRIPTION
Published in `http-client-0.7.14 revision 1`.
Closes #517.
