### PR TITLE
Adds `shouldStripHeaderOnRedirectIfOnDifferentHostOnly` option on `Request`

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,7 @@
 name: Tests
 
 on:
+    workflow_dispatch:
     pull_request:
     push:
         branches:

--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ cabal.sandbox.config
 .stack-work/
 tarballs/
 *~
+dist-newstyle/

--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for http-client
 
+## 0.7.15
+
+* Adds `shouldStripHeaderOnRedirectIfOnDifferentHostOnly` option to `Request` [#520](https://github.com/snoyberg/http-client/pull/520)
+
 ## 0.7.14
 
 * Allow customizing max header length [#514](https://github.com/snoyberg/http-client/pull/514)

--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -162,6 +162,7 @@ module Network.HTTP.Client
     , decompress
     , redirectCount
     , shouldStripHeaderOnRedirect
+    , shouldStripHeaderOnRedirectIfOnDifferentHostOnly
     , checkResponse
     , responseTimeout
     , cookieJar
@@ -264,6 +265,7 @@ responseOpenHistory reqOrig man0 = handle (throwIO . toHttpException reqOrig) $ 
                                             (responseBody res')
                     }
             case getRedirectedRequest
+                    req
                     req'
                     (responseHeaders res)
                     (responseCookieJar res)

--- a/http-client/Network/HTTP/Client/Core.hs
+++ b/http-client/Network/HTTP/Client/Core.hs
@@ -220,7 +220,7 @@ responseOpen inputReq manager' = do
         (req'', res) <- httpRaw' modReq manager
         let mreq = if redirectCount modReq == 0
               then Nothing
-              else getRedirectedRequest req'' (responseHeaders res) (responseCookieJar res) (statusCode (responseStatus res))
+              else getRedirectedRequest modReq req'' (responseHeaders res) (responseCookieJar res) (statusCode (responseStatus res))
         return (res, fromMaybe req'' mreq, isJust mreq))
       req'
 

--- a/http-client/Network/HTTP/Client/Core.hs
+++ b/http-client/Network/HTTP/Client/Core.hs
@@ -220,7 +220,7 @@ responseOpen inputReq manager' = do
         (req'', res) <- httpRaw' modReq manager
         let mreq = if redirectCount modReq == 0
               then Nothing
-              else getRedirectedRequest modReq req'' (responseHeaders res) (responseCookieJar res) (statusCode (responseStatus res))
+              else getRedirectedRequest req' req'' (responseHeaders res) (responseCookieJar res) (statusCode (responseStatus res))
         return (res, fromMaybe req'' mreq, isJust mreq))
       req'
 

--- a/http-client/Network/HTTP/Client/Request.hs
+++ b/http-client/Network/HTTP/Client/Request.hs
@@ -303,6 +303,7 @@ defaultRequest = Request
                 Nothing -> throwIO se
         , requestManagerOverride = Nothing
         , shouldStripHeaderOnRedirect = const False
+        , shouldStripHeaderOnRedirectIfOnDifferentHostOnly = False
         , proxySecureMode = ProxySecureWithConnect
         , redactHeaders = Set.singleton "Authorization"
         }

--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -620,8 +620,8 @@ data Request = Request
     -- ^ Decide whether a header must be stripped from the request
     -- when following a redirect, if host differs from previous request
     -- in redirect chain. Default: false (always strip regardless of host change)
-    -- 
-    -- @since 0.6.2
+    --
+    -- @since 0.7.15
 
     , proxySecureMode :: ProxySecureMode
     -- ^ How to proxy an HTTPS request.

--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -616,6 +616,13 @@ data Request = Request
     --
     -- @since 0.6.2
 
+    , shouldStripHeaderOnRedirectIfOnDifferentHostOnly :: Bool
+    -- ^ Decide whether a header must be stripped from the request
+    -- when following a redirect, if host differs from previous request
+    -- in redirect chain. Default: false (always strip regardless of host change)
+    -- 
+    -- @since 0.6.2
+
     , proxySecureMode :: ProxySecureMode
     -- ^ How to proxy an HTTPS request.
     --

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -1,5 +1,5 @@
 name:                http-client
-version:             0.7.14
+version:             0.7.15
 synopsis:            An HTTP client engine
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client


### PR DESCRIPTION
### Overview
This PR, 
- adds `shouldStripHeaderOnRedirectIfOnDifferentHostOnly` option to `Request`
- modifies `getRedirectedRequest` signature to include original `Request`

### Why?

Many stdlib in other language and ecosystem offer this functionality by default - refer to `golang` and `python-requests` for  example. Potentially leaking headers to different host can lead to security incident. Refer to Python's CVE re this: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2018-20060

Ideally, `shouldStripHeaderOnRedirect` should have only stripped headers if the host differed, so without breaking change, this seems to be second best option.

Previous discussion on this topic: https://github.com/snoyberg/http-client/issues/300

### Testing

- I added few automated tests.

### Remaining 

- [ ] Anything else is needed for contribution or release?
