### PR TITLE
Handle HTTP 103 Early Hints

### DIFF
--- a/http-client/Network/HTTP/Client/Connection.hs
+++ b/http-client/Network/HTTP/Client/Connection.hs
@@ -5,6 +5,7 @@ module Network.HTTP.Client.Connection
     ( connectionReadLine
     , connectionReadLineWith
     , connectionDropTillBlankLine
+    , connectionUnreadLine
     , dummyConnection
     , openSocketConnection
     , openSocketConnectionSize
@@ -59,6 +60,11 @@ connectionReadLineWith mhl conn bs0 =
             (x, S.drop 1 -> y) -> do
                 unless (S.null y) $! connectionUnread conn y
                 return $! killCR $! S.concat $! front [x]
+
+connectionUnreadLine :: Connection -> ByteString -> IO ()
+connectionUnreadLine conn line = do
+  connectionUnread conn (S.pack [charCR, charLF])
+  connectionUnread conn line
 
 charLF, charCR :: Word8
 charLF = 10

--- a/http-client/test-nonet/Network/HTTP/Client/HeadersSpec.hs
+++ b/http-client/test-nonet/Network/HTTP/Client/HeadersSpec.hs
@@ -60,3 +60,21 @@ spec = describe "HeadersSpec" $ do
         statusHeaders `shouldBe` StatusHeaders status200 (HttpVersion 1 1) [ ("foo", "bar") ]
         out >>= (`shouldBe` [])
         inp >>= (`shouldBe` ["result"])
+
+    it "103 early hints" $ do
+        let input =
+                [ "HTTP/1.1 103 Early Hints\r\n"
+                , "Link: </foo.js>\r\n"
+                , "Link: </bar.js>\r\n\r\n"
+                , "HTTP/1.1 200 OK\r\n"
+                , "Content-Type: text/html\r\n\r\n"
+                , "<div></div>"
+                ]
+        (conn, _, inp) <- dummyConnection input
+        statusHeaders <- parseStatusHeaders Nothing conn Nothing Nothing
+        statusHeaders `shouldBe` StatusHeaders status200 (HttpVersion 1 1) [
+          ("Link", "</foo.js>")
+          , ("Link", "</bar.js>")
+          , ("Content-Type", "text/html")
+          ]
+        inp >>= (`shouldBe` ["<div></div>"])


### PR DESCRIPTION
This fixes #521 by handling the 103 Early Hints header specially.

It doesn't quite fix https://github.com/fpco/http-reverse-proxy/issues/44. To make the reverse proxy work properly in the present of 103 Early Hints, I think we need to separate the early hint headers from the normal headers. I don't think that can be done without changing the API. I'm thinking we can add a `responseEarlyHeaders` field to the `Response` object and put them in there instead?