### PR TITLE
Move early hints into `responseEarlyHints` field

### DIFF
--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for http-client
 
+## 0.7.16
+
+* Add `responseEarlyHints` field to `Response`, containing any HTTP 103 Early Hints headers from the server.
+
 ## 0.7.15
 
 * Adds `shouldStripHeaderOnRedirectIfOnDifferentHostOnly` option to `Request` [#520](https://github.com/snoyberg/http-client/pull/520)

--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -2,8 +2,8 @@
 
 ## 0.7.16
 
-* Add `responseEarlyHints` field to `Response`, containing a list of HTTP 103 Early Hints headers received from the server.
-* Add `earlyHintHeaderReceived` callback to `Request`, which will be called on each HTTP 103 Early Hints header received.
+* Add `responseEarlyHints` field to `Response`, containing a list of all HTTP 103 Early Hints headers received from the server.
+* Add `earlyHintHeadersReceived` callback to `Request`, which will be called on each HTTP 103 Early Hints header section received.
 
 ## 0.7.15
 

--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -2,7 +2,8 @@
 
 ## 0.7.16
 
-* Add `responseEarlyHints` field to `Response`, containing any HTTP 103 Early Hints headers from the server.
+* Add `responseEarlyHints` field to `Response`, containing a list of HTTP 103 Early Hints headers received from the server.
+* Add `earlyHintHeaderReceived` callback to `Request`, which will be called on each HTTP 103 Early Hints header received.
 
 ## 0.7.15
 

--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -168,7 +168,7 @@ module Network.HTTP.Client
     , cookieJar
     , requestVersion
     , redactHeaders
-    , earlyHintHeaderReceived
+    , earlyHintHeadersReceived
       -- ** Request body
     , RequestBody (..)
     , Popper

--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -184,6 +184,7 @@ module Network.HTTP.Client
     , responseBody
     , responseCookieJar
     , getOriginalRequest
+    , responseEarlyHints
     , throwErrorStatusCodes
       -- ** Response body
     , BodyReader

--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -168,6 +168,7 @@ module Network.HTTP.Client
     , cookieJar
     , requestVersion
     , redactHeaders
+    , earlyHintHeaderReceived
       -- ** Request body
     , RequestBody (..)
     , Popper

--- a/http-client/Network/HTTP/Client/Connection.hs
+++ b/http-client/Network/HTTP/Client/Connection.hs
@@ -5,6 +5,7 @@ module Network.HTTP.Client.Connection
     ( connectionReadLine
     , connectionReadLineWith
     , connectionDropTillBlankLine
+    , connectionUnreadLine
     , dummyConnection
     , openSocketConnection
     , openSocketConnectionSize
@@ -59,6 +60,11 @@ connectionReadLineWith mhl conn bs0 =
             (x, S.drop 1 -> y) -> do
                 unless (S.null y) $! connectionUnread conn y
                 return $! killCR $! S.concat $! front [x]
+
+connectionUnreadLine :: Connection -> ByteString -> IO ()
+connectionUnreadLine conn line = do
+  connectionUnread conn (S.pack [charCR, charLF])
+  connectionUnread conn line
 
 charLF, charCR :: Word8
 charLF = 10

--- a/http-client/Network/HTTP/Client/Headers.hs
+++ b/http-client/Network/HTTP/Client/Headers.hs
@@ -52,12 +52,12 @@ parseStatusHeaders mhl conn timeout' cont
         (s, v) <- nextStatusLine mhl
         if | statusCode s == 100 -> connectionDropTillBlankLine mhl conn >> return Nothing
            | statusCode s == 103 -> do
-               linkHeaders <- parseHeadersUntilFailure 0 id
+               earlyHeaders <- parseHeadersUntilFailure 0 id
                nextStatusHeaders >>= \case
                    Nothing -> return Nothing
-                   Just (StatusHeaders s' v' reqHeaders) ->
-                       return $ Just $ StatusHeaders s' v' (linkHeaders <> reqHeaders)
-           | otherwise -> Just . StatusHeaders s v A.<$> parseHeaders 0 id
+                   Just (StatusHeaders s' v' earlyHeaders' reqHeaders) ->
+                       return $ Just $ StatusHeaders s' v' (earlyHeaders <> earlyHeaders') reqHeaders
+           | otherwise -> (Just <$>) $ StatusHeaders s v mempty A.<$> parseHeaders 0 id
 
     nextStatusLine :: Maybe MaxHeaderLength -> IO (Status, HttpVersion)
     nextStatusLine mhl = do

--- a/http-client/Network/HTTP/Client/Headers.hs
+++ b/http-client/Network/HTTP/Client/Headers.hs
@@ -28,8 +28,8 @@ charColon = 58
 charPeriod = 46
 
 
-parseStatusHeaders :: Maybe MaxHeaderLength -> Connection -> Maybe Int -> Maybe (IO ()) -> IO StatusHeaders
-parseStatusHeaders mhl conn timeout' cont
+parseStatusHeaders :: Maybe MaxHeaderLength -> Connection -> Maybe Int -> (Header -> IO ()) -> Maybe (IO ()) -> IO StatusHeaders
+parseStatusHeaders mhl conn timeout' onEarlyHintHeader cont
     | Just k <- cont = getStatusExpectContinue k
     | otherwise      = getStatus
   where

--- a/http-client/Network/HTTP/Client/Headers.hs
+++ b/http-client/Network/HTTP/Client/Headers.hs
@@ -16,7 +16,7 @@ import qualified Data.ByteString.Char8          as S8
 import qualified Data.CaseInsensitive           as CI
 import           Data.Maybe (mapMaybe)
 import           Data.Monoid
-import Data.Word (Word8)
+import           Data.Word (Word8)
 import           Network.HTTP.Client.Connection
 import           Network.HTTP.Client.Types
 import           Network.HTTP.Types

--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -259,7 +259,7 @@ mkCreateConnection ms = do
                     , "\r\n"
                     ]
                 parse conn = do
-                    StatusHeaders status _ _ _ <- parseStatusHeaders (managerMaxHeaderLength ms) conn Nothing Nothing
+                    StatusHeaders status _ _ _ <- parseStatusHeaders (managerMaxHeaderLength ms) conn Nothing (\_ -> return ()) Nothing
                     unless (status == status200) $
                         throwHttp $ ProxyConnectException ultHost ultPort status
                 in tlsProxyConnection

--- a/http-client/Network/HTTP/Client/Manager.hs
+++ b/http-client/Network/HTTP/Client/Manager.hs
@@ -259,7 +259,7 @@ mkCreateConnection ms = do
                     , "\r\n"
                     ]
                 parse conn = do
-                    StatusHeaders status _ _ <- parseStatusHeaders (managerMaxHeaderLength ms) conn Nothing Nothing
+                    StatusHeaders status _ _ _ <- parseStatusHeaders (managerMaxHeaderLength ms) conn Nothing Nothing
                     unless (status == status200) $
                         throwHttp $ ProxyConnectException ultHost ultPort status
                 in tlsProxyConnection

--- a/http-client/Network/HTTP/Client/Request.hs
+++ b/http-client/Network/HTTP/Client/Request.hs
@@ -306,7 +306,7 @@ defaultRequest = Request
         , shouldStripHeaderOnRedirectIfOnDifferentHostOnly = False
         , proxySecureMode = ProxySecureWithConnect
         , redactHeaders = Set.singleton "Authorization"
-        , earlyHintHeaderReceived = \_ -> return ()
+        , earlyHintHeadersReceived = \_ -> return ()
         }
 
 -- | Parses a URL via 'parseRequest_'

--- a/http-client/Network/HTTP/Client/Request.hs
+++ b/http-client/Network/HTTP/Client/Request.hs
@@ -306,6 +306,7 @@ defaultRequest = Request
         , shouldStripHeaderOnRedirectIfOnDifferentHostOnly = False
         , proxySecureMode = ProxySecureWithConnect
         , redactHeaders = Set.singleton "Authorization"
+        , earlyHintHeaderReceived = \_ -> return ()
         }
 
 -- | Parses a URL via 'parseRequest_'

--- a/http-client/Network/HTTP/Client/Response.hs
+++ b/http-client/Network/HTTP/Client/Response.hs
@@ -121,7 +121,7 @@ getResponse :: Maybe MaxHeaderLength
             -> IO (Response BodyReader)
 getResponse mhl timeout' req@(Request {..}) mconn cont = do
     let conn = managedResource mconn
-    StatusHeaders s version hs <- parseStatusHeaders mhl conn timeout' cont
+    StatusHeaders s version earlyHs hs <- parseStatusHeaders mhl conn timeout' cont
     let mcl = lookup "content-length" hs >>= readPositiveInt . S8.unpack
         isChunked = ("transfer-encoding", CI.mk "chunked") `elem` map (second CI.mk) hs
 
@@ -162,6 +162,7 @@ getResponse mhl timeout' req@(Request {..}) mconn cont = do
         , responseCookieJar = Data.Monoid.mempty
         , responseClose' = ResponseClose (cleanup False)
         , responseOriginalRequest = req {requestBody = ""}
+        , responseEarlyHints = earlyHs
         }
 
 -- | Does this response have no body?

--- a/http-client/Network/HTTP/Client/Response.hs
+++ b/http-client/Network/HTTP/Client/Response.hs
@@ -121,7 +121,7 @@ getResponse :: Maybe MaxHeaderLength
             -> IO (Response BodyReader)
 getResponse mhl timeout' req@(Request {..}) mconn cont = do
     let conn = managedResource mconn
-    StatusHeaders s version earlyHs hs <- parseStatusHeaders mhl conn timeout' earlyHintHeaderReceived cont
+    StatusHeaders s version earlyHs hs <- parseStatusHeaders mhl conn timeout' earlyHintHeadersReceived cont
     let mcl = lookup "content-length" hs >>= readPositiveInt . S8.unpack
         isChunked = ("transfer-encoding", CI.mk "chunked") `elem` map (second CI.mk) hs
 

--- a/http-client/Network/HTTP/Client/Response.hs
+++ b/http-client/Network/HTTP/Client/Response.hs
@@ -121,7 +121,7 @@ getResponse :: Maybe MaxHeaderLength
             -> IO (Response BodyReader)
 getResponse mhl timeout' req@(Request {..}) mconn cont = do
     let conn = managedResource mconn
-    StatusHeaders s version earlyHs hs <- parseStatusHeaders mhl conn timeout' cont
+    StatusHeaders s version earlyHs hs <- parseStatusHeaders mhl conn timeout' earlyHintHeaderReceived cont
     let mcl = lookup "content-length" hs >>= readPositiveInt . S8.unpack
         isChunked = ("transfer-encoding", CI.mk "chunked") `elem` map (second CI.mk) hs
 

--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -635,7 +635,7 @@ data Request = Request
     --
     -- @since 0.7.13
 
-    , earlyHintHeaderReceived :: Header -> IO ()
+    , earlyHintHeadersReceived :: [Header] -> IO ()
     -- ^ Called every time an HTTP 103 Early Hints header is received from the server.
     --
     -- @since 0.7.16

--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -90,7 +90,7 @@ data Connection = Connection
     }
     deriving T.Typeable
 
-data StatusHeaders = StatusHeaders Status HttpVersion RequestHeaders
+data StatusHeaders = StatusHeaders Status HttpVersion RequestHeaders RequestHeaders
     deriving (Show, Eq, Ord, T.Typeable)
 
 -- | A newtype wrapper which is not exported from this library but is an
@@ -715,6 +715,11 @@ data Response body = Response
     -- via @getOriginalRequest@ instead.
     --
     -- Since 0.7.8
+    , responseEarlyHints :: ResponseHeaders
+    -- ^ Early response headers sent by the server, as part of an HTTP
+    -- 103 Early Hints section.
+    --
+    -- Since 0.7.16
     }
     deriving (Show, T.Typeable, Functor, Data.Foldable.Foldable, Data.Traversable.Traversable)
 

--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -636,7 +636,7 @@ data Request = Request
     -- @since 0.7.13
 
     , earlyHintHeadersReceived :: [Header] -> IO ()
-    -- ^ Called every time an HTTP 103 Early Hints header is received from the server.
+    -- ^ Called every time an HTTP 103 Early Hints header section is received from the server.
     --
     -- @since 0.7.16
     }

--- a/http-client/Network/HTTP/Client/Types.hs
+++ b/http-client/Network/HTTP/Client/Types.hs
@@ -634,6 +634,11 @@ data Request = Request
     -- ^ List of header values being redacted in case we show Request.
     --
     -- @since 0.7.13
+
+    , earlyHintHeaderReceived :: Header -> IO ()
+    -- ^ Called every time an HTTP 103 Early Hints header is received from the server.
+    --
+    -- @since 0.7.16
     }
     deriving T.Typeable
 

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -1,5 +1,5 @@
 name:                http-client
-version:             0.7.15
+version:             0.7.16
 synopsis:            An HTTP client engine
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client

--- a/http-client/test-nonet/Network/HTTP/Client/HeadersSpec.hs
+++ b/http-client/test-nonet/Network/HTTP/Client/HeadersSpec.hs
@@ -60,3 +60,21 @@ spec = describe "HeadersSpec" $ do
         statusHeaders `shouldBe` StatusHeaders status200 (HttpVersion 1 1) [ ("foo", "bar") ]
         out >>= (`shouldBe` [])
         inp >>= (`shouldBe` ["result"])
+
+    it "103 early hints" $ do
+        let input =
+                [ "HTTP/1.1 103 Early Hints\r\n"
+                , "Link: </foo.js>\r\n"
+                , "Link: </bar.js>\r\n\r\n"
+                , "HTTP/1.1 200 OK\r\n"
+                , "Content-Type: text/html\r\n\r\n"
+                , "<div></div>"
+                ]
+        (conn, _, inp) <- dummyConnection input
+        statusHeaders <- parseStatusHeaders Nothing conn Nothing Nothing
+        statusHeaders `shouldBe` StatusHeaders status200 (HttpVersion 1 1) [
+          ("Link", "</foo.js>")
+          , ("Link", "</bar.js>")
+          , ("Content-Type", "text/html")
+          ]
+        inp >>= (`shouldBe` ["<div></div>"])

--- a/http-client/test-nonet/Network/HTTP/Client/HeadersSpec.hs
+++ b/http-client/test-nonet/Network/HTTP/Client/HeadersSpec.hs
@@ -21,7 +21,7 @@ spec = describe "HeadersSpec" $ do
                 ]
         (connection, _, _) <- dummyConnection input
         statusHeaders <- parseStatusHeaders Nothing connection Nothing Nothing
-        statusHeaders `shouldBe` StatusHeaders status200 (HttpVersion 1 1)
+        statusHeaders `shouldBe` StatusHeaders status200 (HttpVersion 1 1) mempty
             [ ("foo", "bar")
             , ("baz", "bin")
             ]
@@ -35,7 +35,7 @@ spec = describe "HeadersSpec" $ do
         (conn, out, _) <- dummyConnection input
         let sendBody = connectionWrite conn "data"
         statusHeaders <- parseStatusHeaders Nothing conn Nothing (Just sendBody)
-        statusHeaders `shouldBe` StatusHeaders status200 (HttpVersion 1 1) [ ("foo", "bar") ]
+        statusHeaders `shouldBe` StatusHeaders status200 (HttpVersion 1 1) [] [ ("foo", "bar") ]
         out >>= (`shouldBe` ["data"])
 
     it "Expect: 100-continue (failure)" $ do
@@ -45,7 +45,7 @@ spec = describe "HeadersSpec" $ do
         (conn, out, _) <- dummyConnection input
         let sendBody = connectionWrite conn "data"
         statusHeaders <- parseStatusHeaders Nothing conn Nothing (Just sendBody)
-        statusHeaders `shouldBe` StatusHeaders status417 (HttpVersion 1 1) []
+        statusHeaders `shouldBe` StatusHeaders status417 (HttpVersion 1 1) [] []
         out >>= (`shouldBe` [])
 
     it "100 Continue without expectation is OK" $ do
@@ -57,7 +57,7 @@ spec = describe "HeadersSpec" $ do
                 ]
         (conn, out, inp) <- dummyConnection input
         statusHeaders <- parseStatusHeaders Nothing conn Nothing Nothing
-        statusHeaders `shouldBe` StatusHeaders status200 (HttpVersion 1 1) [ ("foo", "bar") ]
+        statusHeaders `shouldBe` StatusHeaders status200 (HttpVersion 1 1) [] [ ("foo", "bar") ]
         out >>= (`shouldBe` [])
         inp >>= (`shouldBe` ["result"])
 
@@ -72,9 +72,10 @@ spec = describe "HeadersSpec" $ do
                 ]
         (conn, _, inp) <- dummyConnection input
         statusHeaders <- parseStatusHeaders Nothing conn Nothing Nothing
-        statusHeaders `shouldBe` StatusHeaders status200 (HttpVersion 1 1) [
-          ("Link", "</foo.js>")
-          , ("Link", "</bar.js>")
-          , ("Content-Type", "text/html")
-          ]
+        statusHeaders `shouldBe` StatusHeaders status200 (HttpVersion 1 1)
+            [("Link", "</foo.js>")
+            , ("Link", "</bar.js>")
+            ]
+            [("Content-Type", "text/html")
+            ]
         inp >>= (`shouldBe` ["<div></div>"])

--- a/http-client/test-nonet/Network/HTTP/Client/HeadersSpec.hs
+++ b/http-client/test-nonet/Network/HTTP/Client/HeadersSpec.hs
@@ -75,7 +75,7 @@ spec = describe "HeadersSpec" $ do
                 ]
         (conn, _, inp) <- dummyConnection input
 
-        callbackResults :: MVar (Seq.Seq Header) <- newMVar mempty
+        callbackResults :: MVar (Seq.Seq [Header]) <- newMVar mempty
         let onEarlyHintHeader h = modifyMVar_ callbackResults (return . (Seq.|> h))
 
         statusHeaders <- parseStatusHeaders Nothing conn Nothing onEarlyHintHeader Nothing
@@ -89,9 +89,7 @@ spec = describe "HeadersSpec" $ do
         inp >>= (`shouldBe` ["<div></div>"])
 
         readMVar callbackResults
-          >>= ( `shouldBe`
-                  Seq.fromList
-                    [ ("Link", "</foo.js>"),
-                      ("Link", "</bar.js>")
-                    ]
-              )
+          >>= (`shouldBe` Seq.fromList [
+                  [("Link", "</foo.js>")
+                  , ("Link", "</bar.js>")
+                  ]])

--- a/http-conduit/Network/HTTP/Conduit.hs
+++ b/http-conduit/Network/HTTP/Conduit.hs
@@ -179,6 +179,7 @@ module Network.HTTP.Conduit
     , responseHeaders
     , responseBody
     , responseCookieJar
+    , responseEarlyHints
       -- * Manager
     , Manager
     , newManager


### PR DESCRIPTION
This is a continuation of #523, developing the idea that we can put the early hints into a new field of the `Response` object called `responseEarlyHints`.

AFAICT this is not a breaking change, since the `Response` data constructors are not exposed and the `StatusHeaders` type is only exposed in an internal module.