### PR TITLE
Add low level createConnection/disposeConnection as an alternative to withConnection

### DIFF
--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for http-client
 
+## 0.7.17
+
+* Expose low-level createConnection/disposeConnection functions.
+
 ## 0.7.16
 
 * Add `responseEarlyHints` field to `Response`, containing a list of all HTTP 103 Early Hints headers received from the server.

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -1,5 +1,5 @@
 name:                http-client
-version:             0.7.16
+version:             0.7.17
 synopsis:            An HTTP client engine
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client


### PR DESCRIPTION
I basically needed these functions for UnliftIO reasons. I wanted to use `http-client` to access a WebSocket endpoint, where I need to read and write interactively, as you would with [withConnection](https://hackage.haskell.org/package/http-client-0.7.16/docs/src/Network.HTTP.Client.Core.html#withConnection).

However, `withConnection` wasn't cutting it, because it runs in the `IO` monad, while I want to use a more general monad. IIRC I wasn't able to use MonadUnliftIO to get around it. So I think it would be nice to expose these functions, so users can do general bracket-style stuff with them.
