### PR TITLE
Add managerSetMaxHeaderLength to Client interface

### DIFF
--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for http-client
 
+## 0.7.17
+
+* Add `managerSetMaxHeaderLength` to `Client` to change `ManagerSettings` `MaxHeaderLength`.
+
 ## 0.7.16
 
 * Add `responseEarlyHints` field to `Response`, containing a list of all HTTP 103 Early Hints headers received from the server.

--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -321,6 +321,7 @@ managerSetSecureProxy po m = m { managerProxySecure = po }
 managerSetProxy :: ProxyOverride -> ManagerSettings -> ManagerSettings
 managerSetProxy po = managerSetInsecureProxy po . managerSetSecureProxy po
 
+-- @since 0.7.17
 managerSetMaxHeaderLength :: Int -> ManagerSettings -> ManagerSettings
 managerSetMaxHeaderLength l manager = manager
     { managerMaxHeaderLength = Just $ MaxHeaderLength l }

--- a/http-client/Network/HTTP/Client.hs
+++ b/http-client/Network/HTTP/Client.hs
@@ -112,6 +112,7 @@ module Network.HTTP.Client
     , managerSetProxy
     , managerSetInsecureProxy
     , managerSetSecureProxy
+    , managerSetMaxHeaderLength
     , ProxyOverride
     , proxyFromRequest
     , noProxy
@@ -319,6 +320,10 @@ managerSetSecureProxy po m = m { managerProxySecure = po }
 -- Since 0.4.7
 managerSetProxy :: ProxyOverride -> ManagerSettings -> ManagerSettings
 managerSetProxy po = managerSetInsecureProxy po . managerSetSecureProxy po
+
+managerSetMaxHeaderLength :: Int -> ManagerSettings -> ManagerSettings
+managerSetMaxHeaderLength l manager = manager
+    { managerMaxHeaderLength = Just $ MaxHeaderLength l }
 
 -- $example1
 -- = Example Usage

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -1,5 +1,5 @@
 name:                http-client
-version:             0.7.16
+version:             0.7.17
 synopsis:            An HTTP client engine
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client


### PR DESCRIPTION
I had to add this to support hitting some long urls.