### PR TITLE
http-conduit: Store the cleanup actions of responses in `ResourceT`

### DIFF
--- a/http-conduit/ChangeLog.md
+++ b/http-conduit/ChangeLog.md
@@ -1,5 +1,9 @@
 # ChangeLog for http-conduit
 
+## Unreleased
+
+* Fix space leaks when closing responses [#539](https://github.com/snoyberg/http-client/pull/539)
+
 ## 2.3.8.3
 
 * aeson 2.2 support [#512](https://github.com/snoyberg/http-client/pull/512)


### PR DESCRIPTION
Because `ResourceT` needs to hold onto the `Response` so it can perform cleanup when leaving `runResourceT`, move the cleanup action from the `Response` itself and register it with `ResourceT`. Then all code paths which trigger cleanup (leaving `ResourceT`, consuming the body, calling `responseClose`) will do so by releasing the `Response` from the `ReleaseMap`, preventing a space leak.

Fixes #537 