### PR TITLE
Update http-conduit.cabal

### DIFF
--- a/http-conduit/http-conduit.cabal
+++ b/http-conduit/http-conduit.cabal
@@ -35,7 +35,7 @@ library
                  , conduit               >= 1.2
                  , conduit-extra         >= 1.1
                  , http-types            >= 0.7
-                 , http-client           >= 0.5.13  && < 0.8
+                 , http-client           >= 0.7.16  && < 0.8
                  , http-client-tls       >= 0.3     && < 0.4
                  , mtl
                  , unliftio-core


### PR DESCRIPTION
I encountered the following problem in my project

```
Failed to build http-conduit-2.3.9
...
Network/HTTP/Conduit.hs:182:7: error:
    Not in scope: ‘responseEarlyHints’
    |
182 |     , responseEarlyHints
    |       ^^^^^^^^^^^^^^^^^^

```

I believe you might have forgotten to update the cabal file for the http-conduit library when updating http-client to version 0.7.16.