### PR TITLE
data-default-class -> data-default

### DIFF
--- a/http-client-tls/Network/HTTP/Client/TLS.hs
+++ b/http-client-tls/Network/HTTP/Client/TLS.hs
@@ -26,7 +26,7 @@ module Network.HTTP.Client.TLS
 import Control.Applicative ((<|>))
 import Control.Arrow (first)
 import System.Environment (getEnvironment)
-import Data.Default.Class
+import Data.Default
 import Network.HTTP.Client hiding (host, port)
 import Network.HTTP.Client.Internal hiding (host, port)
 import Control.Exception

--- a/http-client-tls/http-client-tls.cabal
+++ b/http-client-tls/http-client-tls.cabal
@@ -17,7 +17,7 @@ library
   exposed-modules:     Network.HTTP.Client.TLS
   other-extensions:    ScopedTypeVariables
   build-depends:       base >= 4.10 && < 5
-                     , data-default-class
+                     , data-default
                      , http-client >= 0.7.11
                      , crypton-connection
                      , network

--- a/http-conduit/http-conduit.cabal
+++ b/http-conduit/http-conduit.cabal
@@ -63,7 +63,7 @@ test-suite test
     build-depends: base >= 4 && < 5
                  , HUnit
                  , hspec >= 1.3
-                 , data-default-class
+                 , data-default
                  , crypton-connection
                  , warp-tls
                  , tls < 1.5 || >= 1.5.2

--- a/http-conduit/test/main.hs
+++ b/http-conduit/test/main.hs
@@ -48,7 +48,7 @@ import Data.Time.Clock
 import Data.Time.Calendar
 import qualified Network.Wai.Handler.WarpTLS as WT
 import Network.Connection (settingDisableCertificateValidation)
-import Data.Default.Class (def)
+import Data.Default (def)
 #ifdef VERSION_aeson
 import qualified Data.Aeson as A
 #endif


### PR DESCRIPTION
data-default 0.8 deprecates data-default-class by moving the `Default` class from `Data.Default.Class` to `Data.Default`.

See: https://github.com/kazu-yamamoto/crypton-certificate/pull/11
See: https://github.com/haskell-tls/hs-tls/pull/486
See: https://github.com/commercialhaskell/stackage/issues/7545