### PR TITLE
Fix running tests with badssl.com

### DIFF
--- a/http-client-tls/http-client-tls.cabal
+++ b/http-client-tls/http-client-tls.cabal
@@ -46,6 +46,8 @@ test-suite spec
                      , http-client-tls
                      , http-types
                      , crypton-connection
+                     , data-default
+                     , tls
 
 benchmark benchmark
   main-is:             Bench.hs


### PR DESCRIPTION
Since the release of version 2.0.0 of the `tls` package, the default value for `supportedExtendedMainSecret` is `RequireEMS`. The badssl.com website does not support, at the moment, connections using TLS1.2+EMS:
```shell
$ true | openssl s_client -tls1_2 -connect badssl.com:443 2>&1 | sed -rn -e 's/^[[:blank:]]*((Protocol|Extended).*)$/\1/p'
Protocol  : TLSv1.2
Extended master secret: no
```
So, if we build the packages with an updated version of `tls` (>=2.0.0), we have this when we run the tests:
```shell
  test/Spec.hs:47:5: 
  1) BadSSL: we do have case-insensitivity though
       uncaught exception: HttpException
       HttpExceptionRequest Request {
       ...
       }
        (InternalException (HandshakeFailed (Error_Protocol "peer does not support Extended Main Secret" HandshakeFailure)))
```

I'll try to open a PR and/or create an issue in the `badssl.com` project, but for now I would just the `AllowEMS` value.