### PR TITLE
Speed up `stack` CI build

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: stack test --resolver nightly --haddock --no-haddock-deps --lock-file read-write --dry-run
+      - run: stack test --resolver nightly --haddock --no-haddock-deps --lock-file read-write --system-ghc --dry-run
       - uses: actions/cache@v4
         with:
           path: ~/.stack


### PR DESCRIPTION
This is a workaround for https://github.com/commercialhaskell/stack/issues/6696.