### PR TITLE
Propagate managerWrapException setting in mkManagerSettingsContext'

### DIFF
--- a/http-client-tls/Network/HTTP/Client/TLS.hs
+++ b/http-client-tls/Network/HTTP/Client/TLS.hs
@@ -97,7 +97,7 @@ mkManagerSettingsContext' set mcontext tls sockHTTP sockHTTPS = set
                 | ((fromException e)::(Maybe TLS.TLSError))==Just TLS.Error_EOF -> True
 #endif
                 | otherwise -> managerRetryableException defaultManagerSettings e
-    , managerWrapException = \req ->
+    , managerWrapException = \req act ->
         let wrapper se
               | Just (_ :: IOException)          <- fromException se = se'
               | Just (_ :: TLS.TLSException)     <- fromException se = se'
@@ -110,7 +110,7 @@ mkManagerSettingsContext' set mcontext tls sockHTTP sockHTTPS = set
               | otherwise = se
               where
                 se' = toException $ HttpExceptionRequest req $ InternalException se
-         in handle $ throwIO . wrapper
+         in handle (throwIO . wrapper) (managerWrapException set req act)
     }
 
 -- | Default TLS-enabled manager settings


### PR DESCRIPTION
`mkManagerSettingsContext'` replaces a few modifiers in the `Manager`, which prevents the `managerWrapException` from the input settings from being propagated, resulting in the loss of input behaviour.

The change in this PR uses `managerWrapException` from the input manager settings and then applies the handling function.

`mkManagerSettingsContext'` was originally idempotent; this change breaks that idempotency.

The only issue I see is that multiple applications of `mkManagerSettingsContext'` will nest the handler in `managerWrapException`. This occurs when we do something like `newTlsManagerWith tlsManagerSettings`.

**NOTE:** The same issue applies to `managerRetryableException`.

### Some context on why this is required:

We want to hook telemetry (`hs-opentelemetry`) into the HTTP manager. The ideal way to hook telemetry is to integrate it with `managerModifyRequest` and `managerModifyResponse`.

However, `managerModifyRequest` may be called multiple times, so it cannot be used for telemetry purposes. As a workaround, we use `managerWrapException`.