### PR TITLE
Flush the connectionRead buffer before throwing connectionClosed.

### DIFF
--- a/http-client/ChangeLog.md
+++ b/http-client/ChangeLog.md
@@ -1,5 +1,9 @@
 # Changelog for http-client
 
+## 0.7.20
+
+* Fix connectionRead in makeConnection to flush all stacks and throw connectionClosed afterwards.
+
 ## 0.7.19
 
 * Make mockable via `Network.HTTP.Client.Internal.requestAction` [#554](https://github.com/snoyberg/http-client/pull/554)

--- a/http-client/Network/HTTP/Client/Connection.hs
+++ b/http-client/Network/HTTP/Client/Connection.hs
@@ -115,7 +115,10 @@ makeConnection r w c = do
     return $! Connection
         { connectionRead = do
             closed <- readIORef closedVar
-            when closed $ throwHttp ConnectionClosed
+            when closed $ do
+              v <- readIORef istack
+              -- When the stack is empty and the connection is closed, throw an exception.
+              when (v == []) $ throwHttp ConnectionClosed
             join $ atomicModifyIORef istack $ \stack ->
               case stack of
                   x:xs -> (xs, return x)

--- a/http-client/http-client.cabal
+++ b/http-client/http-client.cabal
@@ -1,5 +1,5 @@
 name:                http-client
-version:             0.7.19
+version:             0.7.20
 synopsis:            An HTTP client engine
 description:         Hackage documentation generation is not reliable. For up to date documentation, please see: <http://www.stackage.org/package/http-client>.
 homepage:            https://github.com/snoyberg/http-client


### PR DESCRIPTION
When the response-data has already been read into the buffer, the connection is closed, and the data already read is sufficient, an exception is thrown and the data cannot be read.

In my case, I am using http-client in haskell/servant. The program can not read response data using getResponse and makeLengthReader.
I think https://github.com/haskell-servant/servant/issues/994 might be related, but it's closed for some reason and I'm not sure how to fix it.

This PR flushes the connectionRead buffer before throwing connectionClosed.
