### PR TITLE
Don't let crypton-connection do name resolution

### DIFF
--- a/http-client-tls/Network/HTTP/Client/TLS.hs
+++ b/http-client-tls/Network/HTTP/Client/TLS.hs
@@ -132,8 +132,6 @@ getTlsConnection mcontext tls sock = do
               , NC.connectionUseSocks = sock
               }
         withSocket (const $ pure ()) ha host port $ \socket -> do
-            -- This block is exception-safe thanks to withSocket.
-            -- We won't send TLS bye in case of exception, but that's OK
             conn <- NC.connectFromSocket context socket params
             convertConnection conn
 
@@ -156,8 +154,6 @@ getTlsProxyConnection mcontext tls sock = do
                           $ fromIntegral port
               }
         withSocket (const $ pure ()) ha host port $ \socket -> do
-            -- This block is exception-safe thanks to withSocket.
-            -- We won't send TLS bye in case of exception, but that's OK
             conn <- NC.connectFromSocket context socket params
             NC.connectionPut conn connstr
             conn' <- convertConnection conn

--- a/http-client-tls/Network/HTTP/Client/TLS.hs
+++ b/http-client-tls/Network/HTTP/Client/TLS.hs
@@ -124,15 +124,18 @@ getTlsConnection :: Maybe NC.ConnectionContext
                  -> IO (Maybe HostAddress -> String -> Int -> IO Connection)
 getTlsConnection mcontext tls sock = do
     context <- maybe NC.initConnectionContext return mcontext
-    return $ \_ha host port -> bracketOnError
-        (NC.connectTo context NC.ConnectionParams
-            { NC.connectionHostname = strippedHostName host
-            , NC.connectionPort = fromIntegral port
-            , NC.connectionUseSecure = tls
-            , NC.connectionUseSocks = sock
-            })
-        NC.connectionClose
-        convertConnection
+    return $ \ha host port -> do
+        let params = NC.ConnectionParams
+              { NC.connectionHostname = strippedHostName host
+              , NC.connectionPort = fromIntegral port
+              , NC.connectionUseSecure = tls
+              , NC.connectionUseSocks = sock
+              }
+        withSocket (const $ pure ()) ha host port $ \socket -> do
+            -- This block is exception-safe thanks to withSocket.
+            -- We won't send TLS bye in case of exception, but that's OK
+            conn <- NC.connectFromSocket context socket params
+            convertConnection conn
 
 getTlsProxyConnection
     :: Maybe NC.ConnectionContext
@@ -141,18 +144,21 @@ getTlsProxyConnection
     -> IO (S.ByteString -> (Connection -> IO ()) -> String -> Maybe HostAddress -> String -> Int -> IO Connection)
 getTlsProxyConnection mcontext tls sock = do
     context <- maybe NC.initConnectionContext return mcontext
-    return $ \connstr checkConn serverName _ha host port -> bracketOnError
-        (NC.connectTo context NC.ConnectionParams
-            { NC.connectionHostname = strippedHostName serverName
-            , NC.connectionPort = fromIntegral port
-            , NC.connectionUseSecure = Nothing
-            , NC.connectionUseSocks =
-                case sock of
-                    Just _ -> error "Cannot use SOCKS and TLS proxying together"
-                    Nothing -> Just $ NC.OtherProxy (strippedHostName host) $ fromIntegral port
-            })
-        NC.connectionClose
-        $ \conn -> do
+    return $ \connstr checkConn serverName ha host port -> do
+        let params = NC.ConnectionParams
+              { NC.connectionHostname = strippedHostName serverName
+              , NC.connectionPort = fromIntegral port
+              , NC.connectionUseSecure = Nothing
+              , NC.connectionUseSocks =
+                  case sock of
+                      Just _ -> error "Cannot use SOCKS and TLS proxying together"
+                      Nothing -> Just $ NC.OtherProxy (strippedHostName host)
+                          $ fromIntegral port
+              }
+        withSocket (const $ pure ()) ha host port $ \socket -> do
+            -- This block is exception-safe thanks to withSocket.
+            -- We won't send TLS bye in case of exception, but that's OK
+            conn <- NC.connectFromSocket context socket params
             NC.connectionPut conn connstr
             conn' <- convertConnection conn
 


### PR DESCRIPTION
Instead use the existing resolver.

Fixes #569 <s>and #544</s> (EDIT: no, it doesn't), likely fixes https://github.com/commercialhaskell/stack/issues/5994

The problems is that `crypton-connection` tries addresses [one by one](https://github.com/kazu-yamamoto/crypton-connection/blob/1af72aad1733046195e6f0025adcb7944fa75dad/Network/Connection.hs#L243-L252), so if the fist address returned by `getaddrinfo(3)` is a misconfigured ipv6 address, it'll spend quite a bit of time trying to connect to ipv6 address, and only then try the next address.

Note that `http-client` tries connections [concurrently](https://github.com/snoyberg/http-client/blob/5f0d14724af440e439ce5803b941911609e766e8/http-client/Network/HTTP/Client/Connection.hs#L218-L227).

I tested only `getTlsConnection` part and not ` getTlsProxyConnection` since I don't actually have any proxy on hands. I let maintainer decide what to do next.