### PR TITLE
Don't let crypton-connection resolve hostname 

### DIFF
--- a/http-client-tls/Network/HTTP/Client/TLS.hs
+++ b/http-client-tls/Network/HTTP/Client/TLS.hs
@@ -125,14 +125,14 @@ getTlsConnection :: Maybe NC.ConnectionContext
                  -> IO (Maybe HostAddress -> String -> Int -> IO Connection)
 getTlsConnection mcontext tls sock = do
     context <- maybe NC.initConnectionContext return mcontext
-    return $ \_ha host port -> do
+    return $ \ha host port -> do
         let params = NC.ConnectionParams
               { NC.connectionHostname = strippedHostName host
               , NC.connectionPort = fromIntegral port
               , NC.connectionUseSecure = tls
               , NC.connectionUseSocks = sock
               }
-        withConnection context params
+        withConnection context params ha host port
             convertConnection
 
 getTlsProxyConnection
@@ -142,7 +142,7 @@ getTlsProxyConnection
     -> IO (S.ByteString -> (Connection -> IO ()) -> String -> Maybe HostAddress -> String -> Int -> IO Connection)
 getTlsProxyConnection mcontext tls sock = do
     context <- maybe NC.initConnectionContext return mcontext
-    return $ \connstr checkConn serverName _ha host port -> do
+    return $ \connstr checkConn serverName ha host port -> do
         let params = NC.ConnectionParams
               { NC.connectionHostname = strippedHostName serverName
               , NC.connectionPort = fromIntegral port
@@ -152,7 +152,7 @@ getTlsProxyConnection mcontext tls sock = do
                       Just _ -> error "Cannot use SOCKS and TLS proxying together"
                       Nothing -> Just $ NC.OtherProxy (strippedHostName host) $ fromIntegral port
               }
-        withConnection context params $ \conn -> do
+        withConnection context params ha host port $ \conn -> do
             NC.connectionPut conn connstr
             conn' <- convertConnection conn
 
@@ -162,8 +162,9 @@ getTlsProxyConnection mcontext tls sock = do
 
             return conn'
 
-withConnection :: NC.ConnectionContext -> NC.ConnectionParams -> (NC.Connection -> IO a) -> IO a
-withConnection context params = bracketOnError (NC.connectTo context params) NC.connectionClose
+withConnection :: NC.ConnectionContext -> NC.ConnectionParams -> Maybe HostAddress -> String -> Int -> (NC.Connection -> IO a) -> IO a
+withConnection context params ha host port action = withSocket (const $ pure ()) ha host port $ \socket -> do
+  NC.connectFromSocket context socket params >>= action
 
 convertConnection :: NC.Connection -> IO Connection
 convertConnection conn = makeConnection


### PR DESCRIPTION
Instead use the existing resolver.

@Yuras said in #579:

Fixes #569 <s>and #544</s> (EDIT: no, it doesn't), likely fixes https://github.com/commercialhaskell/stack/issues/5994

The problems is that `crypton-connection` tries addresses [one by one](https://github.com/kazu-yamamoto/crypton-connection/blob/1af72aad1733046195e6f0025adcb7944fa75dad/Network/Connection.hs#L243-L252), so if the fist address returned by `getaddrinfo(3)` is a misconfigured ipv6 address, it'll spend quite a bit of time trying to connect to ipv6 address, and only then try the next address.

Note that `http-client` tries connections [concurrently](https://github.com/snoyberg/http-client/blob/5f0d14724af440e439ce5803b941911609e766e8/http-client/Network/HTTP/Client/Connection.hs#L218-L227).

I tested only `getTlsConnection` part and not ` getTlsProxyConnection` since I don't actually have any proxy on hands. I let maintainer decide what to do next.